### PR TITLE
Fix several issues blocking end-to-end service integration

### DIFF
--- a/pgsqltoolsservice/capabilities/contracts/capabilities_request.py
+++ b/pgsqltoolsservice/capabilities/contracts/capabilities_request.py
@@ -11,14 +11,14 @@ import pgsqltoolsservice.utils as utils
 class CapabilitiesRequestParams:
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         self.host_name = None
         self.host_version = None
 
 
-class CategoryValue():
+class CategoryValue:
     """Defines a category value for a connection option"""
 
     def __init__(self, display_name: str = None, name: str = None):
@@ -26,7 +26,7 @@ class CategoryValue():
         self.name: str = name
 
 
-class ConnectionOption():
+class ConnectionOption:
     """Defines a connection provider option"""
 
     VALUE_TYPE_STRING = 'string'

--- a/pgsqltoolsservice/capabilities/contracts/initialize_request.py
+++ b/pgsqltoolsservice/capabilities/contracts/initialize_request.py
@@ -14,7 +14,7 @@ class InitializeRequestParams:
 
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         self.capabilities: any = None    # TODO: Add support for client capabilities

--- a/pgsqltoolsservice/connection/contracts/common.py
+++ b/pgsqltoolsservice/connection/contracts/common.py
@@ -33,7 +33,7 @@ class ConnectionDetails:
 
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         self.options: dict = None

--- a/pgsqltoolsservice/connection/contracts/connect_request.py
+++ b/pgsqltoolsservice/connection/contracts/connect_request.py
@@ -11,8 +11,8 @@ import pgsqltoolsservice.utils as utils
 class ConnectRequestParams:
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary,
-                                           connection=ConnectionDetails)
+        return utils.convert_from_dict(cls, dictionary,
+                                       connection=ConnectionDetails)
 
     def __init__(self):
         self.connection: ConnectionDetails = None

--- a/pgsqltoolsservice/connection/contracts/disconnect_request.py
+++ b/pgsqltoolsservice/connection/contracts/disconnect_request.py
@@ -10,7 +10,7 @@ import pgsqltoolsservice.utils as utils
 class DisconnectRequestParams:
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         self.owner_uri = None

--- a/pgsqltoolsservice/hosting/json_message.py
+++ b/pgsqltoolsservice/hosting/json_message.py
@@ -4,9 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 from enum import Enum
-import json
 
-import inflection
+import pgsqltoolsservice.utils as utils
 
 
 class JSONRPCMessageType(Enum):
@@ -125,22 +124,22 @@ class JSONRPCMessage:
 
         if self._message_type is JSONRPCMessageType.Request:
             message_base['method'] = self._message_method
-            message_base['params'] = _convert_to_dict(self._message_params)
+            message_base['params'] = utils.convert_to_dict(self._message_params)
             message_base['id'] = self._message_id
             return message_base
 
         if self._message_type is JSONRPCMessageType.ResponseSuccess:
-            message_base['result'] = _convert_to_dict(self._message_result)
+            message_base['result'] = utils.convert_to_dict(self._message_result)
             message_base['id'] = self._message_id
             return message_base
 
         if self._message_type is JSONRPCMessageType.Notification:
             message_base['method'] = self._message_method
-            message_base['params'] = _convert_to_dict(self._message_params)
+            message_base['params'] = utils.convert_to_dict(self._message_params)
             return message_base
 
         if self._message_type is JSONRPCMessageType.ResponseError:
-            message_base['error'] = _convert_to_dict(self._message_error)
+            message_base['error'] = utils.convert_to_dict(self._message_error)
             message_base['id'] = self._message_id
             return message_base
 
@@ -163,27 +162,3 @@ class JSONRPCMessage:
         :return: True if the dictionary representations are not the same, False otherwise
         """
         return not self == other
-
-
-def _convert_to_dict(obj):
-    """
-    Serializes an object to a json-ready dictionary using attribute name normalization. The
-    serialization is repeated, recursively until a built-in type is returned
-    :param obj: The object to convert to a jsonic dictionary
-    :return: A json-ready dictionary representation of the object
-    """
-    return json.loads(json.dumps(obj, default=_get_serializable_value))
-
-
-def _get_serializable_value(obj):
-    """Gets a serializable representation of an object, for use as the default argument to json.dumps"""
-    # If the object is an Enum, use its value
-    if isinstance(obj, Enum):
-        return _get_serializable_value(obj.value)
-    # Try to use the object's dictionary representation if available
-    try:
-        return {inflection.camelize(key, False): value for key, value in obj.__dict__.items()}
-    except AttributeError:
-        pass
-    # Assume the object can be serialized normally
-    return obj

--- a/pgsqltoolsservice/hosting/json_reader.py
+++ b/pgsqltoolsservice/hosting/json_reader.py
@@ -87,8 +87,6 @@ class JSONRPCReader:
                 # We have the content
                 break
 
-            if self._logger is not None:
-                self._logger.debug('Read string %s', content[0])
             return JSONRPCMessage.from_dictionary(json.loads(content[0]))
         except ValueError as ve:
             # Response has invalid json object

--- a/pgsqltoolsservice/hosting/json_rpc_server.py
+++ b/pgsqltoolsservice/hosting/json_rpc_server.py
@@ -70,7 +70,7 @@ class JSONRPCServer:
         streams. Encapsulated into its own method for future async extensions without threads
         """
         if self._logger is not None:
-            self._logger.info(u"JSON RPC server starting...")
+            self._logger.info("JSON RPC server starting...")
 
         self._output_consumer = threading.Thread(
             target=self._consume_output,
@@ -213,16 +213,14 @@ class JSONRPCServer:
         # Figure out which handler will execute the request/notification
         if message.message_type is JSONRPCMessageType.Request:
             if self._logger is not None:
-                self._logger.info('Received request id={} method={}'.format(
-                    message.message_id, message.message_method
-                ))
+                self._logger.info('Received request id=%s method=%s', message.message_id, message.message_method)
             handler = self._request_handlers[message.message_method]
 
             # Make sure we got a handler for the request
             if handler is None:
                 # TODO: Send back an error message that the request method is not supported
                 if self._logger is not None:
-                    self._logger.warn('Requested method is unsupported {}'.format(message.message_method))
+                    self._logger.warn('Requested method is unsupported: %s', message.message_method)
                 return
 
             # Call the handler with a request context and the deserialized parameter object
@@ -237,7 +235,7 @@ class JSONRPCServer:
             handler.handler(request_context, deserialized_object)
         elif message.message_type is JSONRPCMessageType.Notification:
             if self._logger is not None:
-                self._logger.info('Received notification method={}'.format(message.message_method))
+                self._logger.info('Received notification method=%s', message.message_method)
             handler = self._notification_handlers[message.message_method]
 
             if handler is None:
@@ -254,7 +252,7 @@ class JSONRPCServer:
         else:
             # If this happens we have a serious issue with the JSON RPC reader
             if self._logger is not None:
-                self._logger.warn('Received unsupported message type {}'.format(message.message_type))
+                self._logger.warn('Received unsupported message type %s', message.message_type)
             return
 
     def _log_exception(self, ex, thread_name):
@@ -264,7 +262,7 @@ class JSONRPCServer:
         :param thread_name: Name of the thread that encountered the exception
         """
         if self._logger is not None:
-            self._logger.exception('Thread: {} encountered exception {}'.format(thread_name, ex))
+            self._logger.exception('Thread %s encountered exception %s', thread_name, ex)
 
 
 class IncomingMessageConfiguration:

--- a/pgsqltoolsservice/hosting/json_writer.py
+++ b/pgsqltoolsservice/hosting/json_writer.py
@@ -54,4 +54,3 @@ class JSONRPCWriter:
                 message.message_id,
                 message.message_method
             ))
-            self._logger.debug("Sent string %s", json_content)

--- a/pgsqltoolsservice/query_execution/contracts/common.py
+++ b/pgsqltoolsservice/query_execution/contracts/common.py
@@ -23,7 +23,7 @@ class QuerySelection(object):
 
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         self.start_line: int = 0

--- a/pgsqltoolsservice/query_execution/contracts/execute_request.py
+++ b/pgsqltoolsservice/query_execution/contracts/execute_request.py
@@ -17,7 +17,7 @@ class ExecuteRequestParamsBase:
 class ExecuteStringParams(ExecuteRequestParamsBase):
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary)
+        return utils.convert_from_dict(cls, dictionary)
 
     def __init__(self):
         super().__init__()
@@ -33,8 +33,8 @@ EXECUTE_STRING_REQUEST = IncomingMessageConfiguration(
 class ExecuteDocumentSelectionParams(ExecuteRequestParamsBase):
     @classmethod
     def from_dict(cls, dictionary: dict):
-        return utils.deserialize_from_dict(cls, dictionary,
-                                           query_selection=QuerySelection)
+        return utils.convert_from_dict(cls, dictionary,
+                                       query_selection=QuerySelection)
 
     def __init__(self):
         super().__init__()

--- a/pgsqltoolsservice/utils.py
+++ b/pgsqltoolsservice/utils.py
@@ -5,12 +5,15 @@
 
 """Utility functions for the PostgreSQL Tools Service"""
 
+import enum
+import json
+
 import inflection
 
 
-def deserialize_from_dict(class_, dictionary, **kwargs):
+def convert_from_dict(class_, dictionary, **kwargs):
     """
-    Deserializes a class from a json-derived dictionary using attribute name normalization.
+    Converts a class from a json-derived dictionary using attribute name normalization.
     Attributes described in **kwargs will be omitted from automatic attribute definition and the
     provided method will be called to deserialize the value
     :param class_: Class to create an instance of
@@ -39,3 +42,27 @@ def deserialize_from_dict(class_, dictionary, **kwargs):
             setattr(instance, pythonic_attr, dictionary[attr])
 
     return instance
+
+
+def convert_to_dict(obj):
+    """
+    Serializes an object to a json-ready dictionary using attribute name normalization. The
+    serialization is repeated, recursively until a built-in type is returned
+    :param obj: The object to convert to a jsonic dictionary
+    :return: A json-ready dictionary representation of the object
+    """
+    return json.loads(json.dumps(obj, default=_get_serializable_value))
+
+
+def _get_serializable_value(obj):
+    """Gets a serializable representation of an object, for use as the default argument to json.dumps"""
+    # If the object is an Enum, use its value
+    if isinstance(obj, enum.Enum):
+        return _get_serializable_value(obj.value)
+    # Try to use the object's dictionary representation if available
+    try:
+        return {inflection.camelize(key, False): value for key, value in obj.__dict__.items()}
+    except AttributeError:
+        pass
+    # Assume the object can be serialized normally
+    return obj

--- a/tests/utilities_tests.py
+++ b/tests/utilities_tests.py
@@ -1,0 +1,73 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Test utils.py"""
+
+import enum
+import unittest
+
+import pgsqltoolsservice.utils as utils
+
+
+class TestUtils(unittest.TestCase):
+    """Methods for testing utility functions"""
+
+    def test_convert_to_dict(self):
+        """
+        Test that the convert_to_dict function creates the proper dictionary representation of a complex object
+
+        The object includes nested objects, lists containing objects, dicts containing objects, and enums
+        """
+        test_object = _ConversionTestClass()
+        converted_dict = utils.convert_to_dict(test_object)
+        self.assertEqual(converted_dict, test_object.expected_dict())
+
+
+class _ConversionTestClass:
+    """Test class to be used for testing dictionary conversions"""
+
+    def __init__(self):
+        self.test_int = 1
+        self.nested_object = _NestedTestClass()
+        self.list = [_NestedTestClass()]
+        self.dict = {'test_key': _NestedTestClass()}
+        self.enum = _TestEnum.SECOND_OPTION
+
+    def expected_dict(self):
+        """The expected dictionary representation of the instance, for comparison with the utility function output"""
+        return {
+            'testInt': self.test_int,
+            'nestedObject': self.nested_object.expected_dict(),
+            'list': [self.nested_object.expected_dict()],
+            'dict': {
+                'test_key': self.nested_object.expected_dict()
+            },
+            'enum': self.enum.value
+        }
+
+
+class _NestedTestClass:
+    """Test class to be nested within other classes to ensure recursive conversion works"""
+
+    def __init__(self):
+        self.test_int = 1
+        self.test_string = 'test_string'
+
+    def expected_dict(self):
+        """The expected dictionary representation of the instance, for comparison with the utility function output"""
+        return {
+            'testInt': self.test_int,
+            'testString': self.test_string
+        }
+
+
+class _TestEnum(enum.Enum):
+    """Test enum to be included in the _ConversionTestClass to ensure enum conversion works"""
+    FIRST_OPTION = 1
+    SECOND_OPTION = 2
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses several issues that were preventing the PG Tools Service from working end-to-end with Carbon, specifically:
- The InitializeRequestParams contract had a misnamed attribute
- Dictionary serialization did not work for lists
- Logging no longer logged the input/output messages, making it difficult to debug (since we don't have end-to-end debugger support yet)