### PR TITLE
Fix bug that swapped server and db name in connection/complete

### DIFF
--- a/pgsqltoolsservice/connection/connection_service.py
+++ b/pgsqltoolsservice/connection/connection_service.py
@@ -207,7 +207,10 @@ def _build_connection_response(connection_info: ConnectionInfo, connection_type:
     connection = connection_info.get_connection(connection_type)
     dsn_parameters = connection.get_dsn_parameters()
 
-    connection_summary = ConnectionSummary(dsn_parameters['dbname'], dsn_parameters['host'], dsn_parameters['user'])
+    connection_summary = ConnectionSummary(
+        server_name=dsn_parameters['host'],
+        database_name=dsn_parameters['dbname'],
+        user_name=dsn_parameters['user'])
 
     response = ConnectionCompleteParams()
     response.connection_id = connection_info.connection_id


### PR DESCRIPTION
When building the connection summary as part of a connection/complete response, our parameters for db name and server name were swapped, resulting in bugs whenever Carbon tried to use the names.

I fixed the bug and also added a test to make sure the response looks right.

Fixes Microsoft/carbon#1222