### PR TITLE
Adding 'notices' to the message notifications we're sending back to Carbon

### DIFF
--- a/pgsqltoolsservice/query_execution/query_execution_service.py
+++ b/pgsqltoolsservice/query_execution/query_execution_service.py
@@ -109,10 +109,12 @@ class QueryExecutionService(object):
             request_context.send_notification(RESULT_SET_COMPLETE_NOTIFICATION, result_set_params)
 
             # send query/message response
-            message = ''
-            # Only add in rows affected if we had result set summaries
-            if summary.result_set_summaries:
-                message = message + "({0} rows affected)".format(cur.rowcount)
+            message = 'Commands completed successfully'  # TODO: Localize
+            # Only add in rows affected if cursor object's rowcount is not -1.
+            # rowcount is automatically -1 when an operation occurred that
+            # a row count cannot be determined for or execute() was not performed
+            if cur.rowcount != -1:
+                message = "({0} row(s) affected)".format(cur.rowcount)  # TODO: Localize
 
             message_params = self.build_message_params(params.owner_uri, batch_id, message, False)
             request_context.send_notification(MESSAGE_NOTIFICATION, message_params)

--- a/tests/query_execution/test_query_execution_service.py
+++ b/tests/query_execution/test_query_execution_service.py
@@ -140,7 +140,7 @@ class TestQueryService(unittest.TestCase):
 
         # Set up the request context and request parameters
         mock_request_context = utils.MockRequestContext()
-        params = utils.get_execute_string_params()
+        params = get_execute_string_params()
 
         # If I try to handle a query request with an invalid owner URI
         query_execution_service._handle_execute_query_request(mock_request_context, params)
@@ -166,7 +166,7 @@ class TestQueryService(unittest.TestCase):
 
         # Set up the request context and request parameters
         mock_request_context = utils.MockRequestContext()
-        params = utils.get_execute_string_params()
+        params = get_execute_string_params()
 
         # If I handle a query that raises an error when executed
         query_execution_service._handle_execute_query_request(mock_request_context, params)
@@ -198,7 +198,7 @@ class TestQueryService(unittest.TestCase):
 
         # Set up the request context and request parameters
         mock_request_context = utils.MockRequestContext()
-        params = utils.get_execute_string_params()
+        params = get_execute_string_params()
 
         # If I handle a query
         try:
@@ -304,8 +304,7 @@ class TestQueryService(unittest.TestCase):
     def test_message_notices_no_error(self):
         """Test to make sure that notices are being sent as part of a message notification"""
         # Set up params that are sent as part of a query execution request
-        params = utils.get_execute_string_params()
-
+        params = get_execute_string_params()
         # If we handle an execute query request
         self.query_execution_service._handle_execute_query_request(self.request_context, params)
 
@@ -338,28 +337,28 @@ class TestQueryService(unittest.TestCase):
         """
         # Set up query execution side effect and params sent as part of a QE request
         self.cursor.execute = mock.Mock(side_effect=self.cursor.execute_failure_side_effects)
-        params = utils.get_execute_string_params()
+        params = get_execute_string_params()
 
         # If we handle an execute query request
         self.query_execution_service._handle_execute_query_request(self.request_context, params)
 
-        # Then we executed the query, closed the cursor, 
+        # Then we executed the query, closed the cursor,
         # did not call fetchall(), and cleared the notices
         self.cursor.execute.assert_called_once()
         self.cursor.close.assert_called_once()
         self.cursor.fetchall.assert_not_called()
         self.assertEqual(self.connection.notices, [])
-        
+
         # Get the message params for all message notifications that were sent
         # call[0] would refer to the name of the notification call. call[1] allows
         # access to the arguments list of the notification call
         notification_calls = self.request_context.send_notification.mock_calls
         call_params_list = [call[1][1] for call in notification_calls if call[1][0] == MESSAGE_NOTIFICATION]
-        
+
         # Assert that only two message notifications were sent.
         # The first is a message containing only the notifications, where is_error is false
         # The second is the error message, where is_error is true
-        expected_notices =  ["NOTICE: foo", "DEBUG: bar"]
+        expected_notices = ["NOTICE: foo", "DEBUG: bar"]
         self.assertEqual(len(call_params_list), 2)
         self.assertFalse(call_params_list[0].message.is_error)
         self.assertTrue(call_params_list[1].message.is_error)
@@ -367,6 +366,14 @@ class TestQueryService(unittest.TestCase):
 
         # Make sure that the whole first message consists of the notices, as expected
         self.assertEqual(notices_str, call_params_list[0].message.message)
+
+
+def get_execute_string_params() -> ExecuteStringParams:
+    """Get a simple ExecutestringParams"""
+    params = ExecuteStringParams()
+    params.query = 'select version()'
+    params.owner_uri = 'test_uri'
+    return params
 
 
 if __name__ == '__main__':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,6 @@ import unittest.mock as mock
 import psycopg2
 
 from pgsqltoolsservice.hosting import NotificationContext, RequestContext
-from pgsqltoolsservice.query_execution.contracts import ExecuteStringParams
 
 
 def get_mock_notification_context() -> NotificationContext:
@@ -41,14 +40,6 @@ def get_mock_logger() -> logging.Logger:
     mock_logger.log = mock.MagicMock()
 
     return mock_logger
-
-
-def get_execute_string_params() -> ExecuteStringParams:
-    """Get a simple ExecutestringParams"""
-    params = ExecuteStringParams()
-    params.query = 'select version()'
-    params.owner_uri = 'test_uri'
-    return params
 
 
 class MockRequestContext(RequestContext):
@@ -113,6 +104,7 @@ class MockCursor:
         self.close = mock.Mock()
         self.connection = mock.Mock()
         self.description = None
+        self.rowcount = -1
 
     def execute_success_side_effects(self, query: str):
         """Set up dummy results for query execution success"""


### PR DESCRIPTION
Added in 'notices' from the connection object to the messages we're sending back to Carbon. This consists of logging output sent back to the client. Tests were also added to prevent regression.

To turn on notices
1. run the following query: 'SHOW config_file;'
2. Open the config file specified in the output of this query
3. Set log_statement = 'all'
4. Set client_min_messages to the appropriate level, where the value 'debug5' (no quotes) allows all messages to be output to notices and the value of 'error' (no quotes) would just filter messages that fit under an Error type to be output to notices.