### PR TITLE
Query execution tests for subset requests, query execution, and result sets

### DIFF
--- a/tests/query_execution/test_query_execution_service.py
+++ b/tests/query_execution/test_query_execution_service.py
@@ -312,12 +312,8 @@ class TestQueryService(unittest.TestCase):
         summary = batch.build_batch_summary()
         owner_uri = 'test_uri'
 
-        # Set up the mock query execution service
-        query_execution_service = QueryExecutionService()
-        query_execution_service._service_provider = ServiceProvider(None, {}, utils.get_mock_logger())
-
         # If I build a result set complete response from the summary
-        result = query_execution_service.build_result_set_complete_params(summary, owner_uri)
+        result = self.query_execution_service.build_result_set_complete_params(summary, owner_uri)
 
         # Then the parameters should have an owner uri and result set summary that matches the ones provided
         self.assertEqual(result.owner_uri, owner_uri)


### PR DESCRIPTION
This PR adds unit tests within query execution for some code that was previously untested, including the subset request, building result sets, and testing that the correct notifications and responses are sent when running a query.