### PR TITLE
Use common SQL settings for Intellisense

### DIFF
--- a/pgsqltoolsservice/workspace/__init__.py
+++ b/pgsqltoolsservice/workspace/__init__.py
@@ -3,12 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from pgsqltoolsservice.workspace.contracts import PGSQLConfiguration, IntellisenseConfiguration
+from pgsqltoolsservice.workspace.contracts import SQLConfiguration, IntellisenseConfiguration
 from pgsqltoolsservice.workspace.script_file import ScriptFile
 from pgsqltoolsservice.workspace.workspace_service import WorkspaceService
 from pgsqltoolsservice.workspace.workspace import Workspace
 
 __all__ = [
-    'PGSQLConfiguration', 'IntellisenseConfiguration',
+    'SQLConfiguration', 'IntellisenseConfiguration',
     'ScriptFile', 'WorkspaceService', 'Workspace'
 ]

--- a/pgsqltoolsservice/workspace/contracts/__init__.py
+++ b/pgsqltoolsservice/workspace/contracts/__init__.py
@@ -5,7 +5,7 @@
 
 from pgsqltoolsservice.workspace.contracts.did_change_config_notification import (
     DID_CHANGE_CONFIG_NOTIFICATION, DidChangeConfigurationParams,
-    Configuration, PGSQLConfiguration, IntellisenseConfiguration
+    Configuration, SQLConfiguration, IntellisenseConfiguration
 )
 from pgsqltoolsservice.workspace.contracts.did_change_text_doc_notification import (
     DID_CHANGE_TEXT_DOCUMENT_NOTIFICATION, DidChangeTextDocumentParams, TextDocumentChangeEvent
@@ -22,7 +22,7 @@ from pgsqltoolsservice.workspace.contracts.common import (
 
 __all__ = [
     'DID_CHANGE_CONFIG_NOTIFICATION', 'DidChangeConfigurationParams',
-    'Configuration', 'PGSQLConfiguration', 'IntellisenseConfiguration',
+    'Configuration', 'SQLConfiguration', 'IntellisenseConfiguration',
     'DID_CHANGE_TEXT_DOCUMENT_NOTIFICATION', 'DidChangeTextDocumentParams', 'TextDocumentChangeEvent',
     'DID_OPEN_TEXT_DOCUMENT_NOTIFICATION', 'DidOpenTextDocumentParams',
     'DID_CLOSE_TEXT_DOCUMENT_NOTIFICATION', 'DidCloseTextDocumentParams',

--- a/pgsqltoolsservice/workspace/contracts/did_change_config_notification.py
+++ b/pgsqltoolsservice/workspace/contracts/did_change_config_notification.py
@@ -7,9 +7,9 @@ from pgsqltoolsservice.hosting import IncomingMessageConfiguration
 import pgsqltoolsservice.utils as utils
 
 
-class PGSQLConfiguration:
+class SQLConfiguration:
     """
-    Configuration for PGSQL tool service
+    Configuration for SQL settings in general. These are common to any SQL provider
     """
     @classmethod
     def from_dict(cls, dictionary: dict):
@@ -19,6 +19,20 @@ class PGSQLConfiguration:
 
     def __init__(self):
         self.intellisense: IntellisenseConfiguration = IntellisenseConfiguration()
+
+# TODO reenable this when there are PG-specific settings
+# class PGSQLConfiguration:
+#     """
+#     Configuration for PGSQL tool service
+#     """
+#     @classmethod
+#     def from_dict(cls, dictionary: dict):
+#         return utils.serialization.convert_from_dict(cls, dictionary,
+#                                                      ignore_extra_attributes=True,
+#                                                      intellisense=IntellisenseConfiguration)
+
+#     def __init__(self):
+#         self.intellisense: IntellisenseConfiguration = IntellisenseConfiguration()
 
 
 class IntellisenseConfiguration:
@@ -44,10 +58,10 @@ class Configuration:
     @classmethod
     def from_dict(cls, dictionary: dict):
         return utils.serialization.convert_from_dict(cls, dictionary,
-                                                     pgsql=PGSQLConfiguration)
+                                                     sql=SQLConfiguration)
 
     def __init__(self):
-        self.pgsql = None
+        self.sql = None
 
 
 class DidChangeConfigurationParams:

--- a/pgsqltoolsservice/workspace/workspace_service.py
+++ b/pgsqltoolsservice/workspace/workspace_service.py
@@ -12,7 +12,7 @@ from pgsqltoolsservice.workspace.contracts import (
     DID_CHANGE_TEXT_DOCUMENT_NOTIFICATION, DidChangeTextDocumentParams,
     DID_OPEN_TEXT_DOCUMENT_NOTIFICATION, DidOpenTextDocumentParams,
     DID_CLOSE_TEXT_DOCUMENT_NOTIFICATION, DidCloseTextDocumentParams,
-    PGSQLConfiguration, Range
+    SQLConfiguration, Range
 )
 from pgsqltoolsservice.workspace.script_file import ScriptFile
 from pgsqltoolsservice.workspace.workspace import Workspace
@@ -32,10 +32,10 @@ class WorkspaceService:
 
         # Create a workspace that will handle state for the session
         self._workspace = Workspace()
-        self._configuration: PGSQLConfiguration = PGSQLConfiguration()
+        self._configuration: SQLConfiguration = SQLConfiguration()
 
         # Setup callbacks for the various events we can receive
-        self._config_change_callbacks: List[Callable[PGSQLConfiguration]] = []
+        self._config_change_callbacks: List[Callable[SQLConfiguration]] = []
         self._text_change_callbacks: List[Callable[ScriptFile]] = []
         self._text_open_callbacks: List[Callable[ScriptFile]] = []
         self._text_close_callbacks: List[Callable[ScriptFile]] = []
@@ -56,7 +56,7 @@ class WorkspaceService:
 
     # PROPERTIES ###########################################################
     @property
-    def configuration(self) -> PGSQLConfiguration:
+    def configuration(self) -> SQLConfiguration:
         return self._configuration
 
     @property
@@ -65,7 +65,7 @@ class WorkspaceService:
         return self._workspace
 
     # METHODS ##############################################################
-    def register_config_change_callback(self, task: Callable[[PGSQLConfiguration], None]) -> None:
+    def register_config_change_callback(self, task: Callable[[SQLConfiguration], None]) -> None:
         self._config_change_callbacks.append(task)
 
     def register_text_change_callback(self, task: Callable[[ScriptFile], None]) -> None:
@@ -106,7 +106,7 @@ class WorkspaceService:
         :param notification_context: Context of the notification
         :param params: Parameters from the notification
         """
-        self._configuration = params.settings.pgsql
+        self._configuration = params.settings.sql
         for callback in self._config_change_callbacks:
             callback(self._configuration)
 

--- a/tests/language/test_language_service.py
+++ b/tests/language/test_language_service.py
@@ -22,7 +22,7 @@ from pgsqltoolsservice.language.contracts import (
 )
 from pgsqltoolsservice.utils import constants
 from pgsqltoolsservice.workspace import (
-    WorkspaceService, PGSQLConfiguration, ScriptFile, Workspace
+    WorkspaceService, SQLConfiguration, ScriptFile, Workspace
 )
 from pgsqltoolsservice.workspace.contracts import (
     Range
@@ -81,7 +81,7 @@ class TestLanguageService(unittest.TestCase):
         """
         # If: intellisense is disabled
         context: RequestContext = utils.MockRequestContext()
-        self.mock_workspace_service._configuration = PGSQLConfiguration()
+        self.mock_workspace_service._configuration = SQLConfiguration()
         self.mock_workspace_service._configuration.intellisense.enable_intellisense = False
         service: LanguageService = self._init_service()
 
@@ -100,7 +100,7 @@ class TestLanguageService(unittest.TestCase):
         """
         # If: The script file doesn't exist (there is an empty workspace)
         context: RequestContext = utils.MockRequestContext()
-        config: PGSQLConfiguration = PGSQLConfiguration()
+        config: SQLConfiguration = SQLConfiguration()
 
         self.mock_workspace_service._configuration = config
         self.mock_workspace_service._workspace = Workspace()
@@ -131,7 +131,7 @@ class TestLanguageService(unittest.TestCase):
             }
         })
         context: RequestContext = utils.MockRequestContext()
-        self.mock_workspace_service._configuration = PGSQLConfiguration()
+        self.mock_workspace_service._configuration = SQLConfiguration()
         self.mock_workspace_service._configuration.intellisense.enable_intellisense = True
         workspace, script_file = self._get_test_workspace(True, input_text)
         self.mock_workspace_service._workspace = workspace

--- a/tests/workspace/test_workspace_service.py
+++ b/tests/workspace/test_workspace_service.py
@@ -11,7 +11,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from pgsqltoolsservice.hosting import JSONRPCServer, NotificationContext, ServiceProvider   # noqa
-from pgsqltoolsservice.workspace import WorkspaceService, PGSQLConfiguration, IntellisenseConfiguration     # noqa
+from pgsqltoolsservice.workspace import WorkspaceService, SQLConfiguration, IntellisenseConfiguration     # noqa
 from pgsqltoolsservice.workspace.workspace import Workspace, ScriptFile
 from pgsqltoolsservice.workspace.contracts import (
     DidChangeConfigurationParams,
@@ -33,7 +33,7 @@ class TestWorkspaceService(unittest.TestCase):
 
         # Then:
         # ... The service should have configuration and expose it via the property
-        self.assertIsInstance(ws._configuration, PGSQLConfiguration)
+        self.assertIsInstance(ws._configuration, SQLConfiguration)
         self.assertIs(ws.configuration, ws._configuration)
 
         # ... The service should have a workspace
@@ -111,7 +111,7 @@ class TestWorkspaceService(unittest.TestCase):
         nc: NotificationContext = utils.get_mock_notification_context()
         params: DidChangeConfigurationParams = DidChangeConfigurationParams.from_dict({
             'settings': {
-                'pgsql': {
+                'sql': {
                     'intellisense': {
                         'enable_intellisense': False
                     }
@@ -125,13 +125,13 @@ class TestWorkspaceService(unittest.TestCase):
         nc.send_notification.assert_not_called()
 
         # ... The config should have been updated
-        self.assertIs(ws.configuration, params.settings.pgsql)
+        self.assertIs(ws.configuration, params.settings.sql)
         # ... And default values that weren't specified in the notification are preserved
         self.assertTrue(ws.configuration.intellisense.enable_suggestions)
 
         # ... The mock config change callbacks should have been called
         for callback in ws._config_change_callbacks:
-            callback.assert_called_once_with(params.settings.pgsql)
+            callback.assert_called_once_with(params.settings.sql)
 
     def test_handle_text_notification_none(self):
         # Setup:


### PR DESCRIPTION
- Main configuration is now 'sql' instead of 'pgsql'
- Will refactor and add back in 'pgsql' once there are pg-specific settings to deserialize and handle