### PR TITLE
Fix setup.py for pgsmo templates - attempt #1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,18 @@ from cx_Freeze import setup, Executable
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
-buildOptions = dict(packages=[], excludes=[])
+include_files = [
+    './pgsmo/objects/column/templates', 
+    './pgsmo/objects/database/templates', 
+    './pgsmo/objects/role/templates', 
+    './pgsmo/objects/schema/templates', 
+    './pgsmo/objects/server/templates', 
+    './pgsmo/objects/table/templates', 
+    './pgsmo/objects/tablespace/templates', 
+    './pgsmo/objects/view/view_templates'
+]
+
+buildOptions = dict(packages=['asyncio'], excludes=[], include_files=include_files)
 
 base = 'Console'
 


### PR DESCRIPTION
setup.py needed to be modified to copy over all the template .sql files for pgsmo. I also ran into an error with some of the pgsmo dependencies that required explicitly adding asyncio as a package for the build.