### PR TITLE
Add asyncio package explicitly to build script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from cx_Freeze import setup, Executable
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
-buildOptions = dict(packages=[], excludes=[])
+buildOptions = dict(packages=['asyncio'], excludes=[])
 
 base = 'Console'
 


### PR DESCRIPTION
This fixed a bug that was caught when doing the Mac release but which wasn't brought over to master yet.