### PR TITLE
Require dbname parameter for connections, and use postgres as the default

### DIFF
--- a/pgsqltoolsservice/capabilities/capabilities_service.py
+++ b/pgsqltoolsservice/capabilities/capabilities_service.py
@@ -56,8 +56,9 @@ class CapabilitiesService:
                 value_type=ConnectionOption.VALUE_TYPE_STRING,
                 special_value_type=ConnectionOption.SPECIAL_VALUE_DATABASE_NAME,
                 is_identity=True,
-                is_required=False,
-                group_name='Source'
+                is_required=True,
+                group_name='Source',
+                default_value='postgres'
             ),
             ConnectionOption(
                 name='user',


### PR DESCRIPTION
This change makes the dbname connection parameter required, and uses postgres as the default.

This is part of the work for Microsoft/carbon#1350. Currently the tools service defers to psycopg2's default behavior when the database name is blank, which is to connect to a database with the same name as the username. This results in weird error messages if the database does not exist, since it's not clear why Carbon is trying to connect to the database that can't be found.

There will need to be Carbon-side changes to support this feature as well, since right now Carbon doesn't appear to respect defaults for non-advanced options.