### PR TITLE
Fix logging location to avoid errors on OS X

### DIFF
--- a/pgsqltoolsservice/pgtoolsservice_main.py
+++ b/pgsqltoolsservice/pgtoolsservice_main.py
@@ -5,6 +5,7 @@
 
 import io
 import logging
+import os
 import sys
 
 import ptvsd
@@ -24,7 +25,10 @@ from pgsqltoolsservice.workspace import WorkspaceService
 if __name__ == '__main__':
     # Create the output logger
     logger = logging.getLogger('pgsqltoolsservice')
-    handler = logging.FileHandler('pgsqltoolsservice.log')
+    try:
+        handler = logging.FileHandler(os.path.join(os.path.dirname(sys.argv[0]), 'pgsqltoolsservice.log'))
+    except Exception:
+        handler = logging.NullHandler()
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)


### PR DESCRIPTION
This PR updates the default log location to use whatever folder the program is running in, in order to avoid issues in Carbon releases on OS X. It also adds an exception handler around the logging handler so that an error with the file will never crash the service.

Closes Microsoft/carbon#1392