### PR TITLE
Fixing major bug in ConnectionDetails.from_dict

### DIFF
--- a/pgsqltoolsservice/connection/contracts/common.py
+++ b/pgsqltoolsservice/connection/contracts/common.py
@@ -26,8 +26,8 @@ class ConnectionDetails:
     def from_data(cls, server_name: str, database_name: str, user_name: str, opts: dict):
         obj = cls()
         obj.user_name = user_name
-        obj.database_name = database_name,
-        obj.server_name = server_name,
+        obj.database_name = database_name
+        obj.server_name = server_name
         obj.options = opts
         return obj
 


### PR DESCRIPTION
(cherry picked from commit aeaee31)

Major whoops on my part, commas at the end of an assignment automatically turn the assignment into a tuple. So for example `obj.database_name` was being assigned as `(database_name, )`

This doesn't actually matter to any of the actual code paths because we don't use ConnectionDetails.from_data anywhere aside from tests.