### PR TITLE
Fix for broken schema expand

### DIFF
--- a/pgsqltoolsservice/object_explorer/routing.py
+++ b/pgsqltoolsservice/object_explorer/routing.py
@@ -160,7 +160,7 @@ def _tables(is_refresh: bool, current_path: str, session: ObjectExplorerSession,
 def _schemas(is_refresh: bool, current_path: str, session: ObjectExplorerSession, match_params: dict) -> List[NodeInfo]:
     """Function to generate a list of NodeInfo for tables in a schema"""
     parent_obj = _get_obj_with_refresh(session.server.maintenance_db, is_refresh)
-    return [_get_node_info(node, current_path, 'Schema', is_leaf=False) for node in parent_obj]
+    return [_get_node_info(node, current_path, 'Schema', is_leaf=False) for node in parent_obj.schemas]
 
 
 def _views(is_refresh: bool, current_path: str, session: ObjectExplorerSession, match_params: dict) -> List[NodeInfo]:


### PR DESCRIPTION
Fixing mistake during merge caused by forgetting to iterate over schemas instead of the single database