### PR TITLE
Add scripting to the backup contract and handle pg_dump errors

### DIFF
--- a/pgsqltoolsservice/disaster_recovery/contracts/backup.py
+++ b/pgsqltoolsservice/disaster_recovery/contracts/backup.py
@@ -30,6 +30,7 @@ class BackupParams:
     def __init__(self):
         self.owner_uri: str = None
         self.backup_info: BackupInfo = None
+        self.is_scripting: bool = None
 
 
 class BackupInfo:

--- a/pgsqltoolsservice/disaster_recovery/disaster_recovery_service.py
+++ b/pgsqltoolsservice/disaster_recovery/disaster_recovery_service.py
@@ -64,9 +64,9 @@ def _perform_backup(connection_info: ConnectionInfo, params: BackupParams) -> Ta
                     f'--username={connection_info.details.options["user"]}']
     pg_dump_process = subprocess.Popen(pg_dump_args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
     # pg_dump will prompt for the password, so send it via stdin. This call will block until the process exits.
-    pg_dump_process.communicate(str.encode(connection_info.details.options.get('password') or ''))
+    _, stderr = pg_dump_process.communicate(str.encode(connection_info.details.options.get('password') or ''))
     if pg_dump_process.returncode != 0:
-        return TaskResult(TaskStatus.FAILED, str(pg_dump_process.stderr.read()))
+        return TaskResult(TaskStatus.FAILED, str(stderr, 'utf-8'))
     return TaskResult(TaskStatus.SUCCEEDED)
 
 


### PR DESCRIPTION
This PR fixes a couple bugs in how we handle backups, specifically that the backup contract was not updated to handle the new isScripting parameter in BackupParams, as well as a bug displaying stderr if pg_dump fails.