### PR TITLE
Update restore contracts to use new serialization

### DIFF
--- a/pgsqltoolsservice/disaster_recovery/contracts/restore.py
+++ b/pgsqltoolsservice/disaster_recovery/contracts/restore.py
@@ -8,7 +8,6 @@
 from pgsqltoolsservice.capabilities.contracts import FeatureMetadataProvider, ServiceOption
 from pgsqltoolsservice.hosting import IncomingMessageConfiguration
 from pgsqltoolsservice.serialization import Serializable
-import pgsqltoolsservice.utils as utils
 
 
 class RestoreParams(Serializable):


### PR DESCRIPTION
Due to some merge issues the restore contracts did not get updated to use the new style of serialization, causing master to be broken. This PR fixes those contracts.