### PR TITLE
Rename log to pgtoolsservice.log and let user specify log-dir

### DIFF
--- a/pgsqltoolsservice/pgtoolsservice_main.py
+++ b/pgsqltoolsservice/pgtoolsservice_main.py
@@ -25,18 +25,9 @@ from pgsqltoolsservice.utils import constants
 from pgsqltoolsservice.workspace import WorkspaceService
 
 if __name__ == '__main__':
-    # Create the output logger
-    logger = logging.getLogger('pgsqltoolsservice')
-    try:
-        handler = logging.FileHandler(os.path.join(os.path.dirname(sys.argv[0]), 'pgsqltoolsservice.log'))
-    except Exception:
-        handler = logging.NullHandler()
-    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.DEBUG)
-
     # See if we have any arguments
+    wait_for_debugger = False
+    log_dir = None
     stdin = None
     if len(sys.argv) > 1:
         for arg in sys.argv:
@@ -50,9 +41,30 @@ if __name__ == '__main__':
                 except IndexError:
                     pass
                 ptvsd.enable_attach('', address=('0.0.0.0', port))
+                if arg_parts[0] == '--enable-remote-debugging-wait':
+                    wait_for_debugger = True
+            elif arg_parts[0] == '--log-dir':
+                log_dir = arg_parts[1]
             if arg_parts[0] == '--enable-remote-debugging-wait':
-                logger.debug('Waiting for a debugger to attach...')
-                ptvsd.wait_for_attach()
+                wait_for_debugger = True
+
+    # Create the output logger
+    logger = logging.getLogger('pgsqltoolsservice')
+    try:
+        if not log_dir:
+            log_dir = os.path.dirname(sys.argv[0])
+        handler = logging.FileHandler(os.path.join(log_dir, 'pgtoolsservice.log'))
+    except Exception:
+        handler = logging.NullHandler()
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    # Wait for the debugger to attach if needed
+    if wait_for_debugger:
+        logger.debug('Waiting for a debugger to attach...')
+        ptvsd.wait_for_attach()
 
     # Wrap standard in and out in io streams to add readinto support
     if stdin is None:


### PR DESCRIPTION
This is a quick PR to address Microsoft/carbon#1754. It adds the ability to use a '--log-dir' flag when starting pgToolsService in order to specify the log location.

There's more work to be done with how we handle command line arguments and with logging, which I'll do as part of my fundamentals work this sprint, but I wanted to get this PR out separately in order to quickly unblock Leila's work