### PR TITLE
Log setup - Remove duplicated remote debugging check

### DIFF
--- a/pgsqltoolsservice/pgtoolsservice_main.py
+++ b/pgsqltoolsservice/pgtoolsservice_main.py
@@ -45,8 +45,6 @@ if __name__ == '__main__':
                     wait_for_debugger = True
             elif arg_parts[0] == '--log-dir':
                 log_dir = arg_parts[1]
-            if arg_parts[0] == '--enable-remote-debugging-wait':
-                wait_for_debugger = True
 
     # Create the output logger
     logger = logging.getLogger('pgsqltoolsservice')


### PR DESCRIPTION
As part of my PR to enable the `--log-dir` flag I duplicated a check for `--enable-remote-debugging-wait` (lines 44-45 and 48-49). This PR removes that duplicate