### PR TITLE
PGSMO: Fix for function expansion failure

### DIFF
--- a/pgsmo/objects/functions/function_base.py
+++ b/pgsmo/objects/functions/function_base.py
@@ -160,6 +160,7 @@ class FunctionBase(NodeObject, ScriptableCreate, ScriptableDelete, ScriptableUpd
         return self._full_properties.get("cascade")
 
     # IMPLEMENTATION DETAILS ###############################################
+    @classmethod
     def _macro_root(cls) -> List[str]:
         return [cls.MACRO_ROOT]
 


### PR DESCRIPTION
Forgot to add the `@class_method` decorator to the `_macro_root` property.