### PR TITLE
Fix mock imports in some tests

### DIFF
--- a/tests/language/completion/metadata.py
+++ b/tests/language/completion/metadata.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 from itertools import product
-from mock import Mock
+from unittest.mock import Mock
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 

--- a/tests/language/completion/test_naive_completion.py
+++ b/tests/language/completion/test_naive_completion.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from mock import Mock
+from unittest.mock import Mock
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 

--- a/tests/language/test_completion_refresher.py
+++ b/tests/language/test_completion_refresher.py
@@ -6,7 +6,7 @@
 from typing import List, Any
 import time
 import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pgsmo import NodeCollection, Server
 from pgsqltoolsservice.language.completion_refresher import CompletionRefresher


### PR DESCRIPTION
Some tests were failing because they use `from mock import Mock` rather than `from unittest.mock import Mock`. These failures weren't revealed locally for us or on the build machines because all those machines have the pip package "mock" installed (likely from a previous project requirement), but were failing for people who don't have "mock" installed.

Separately I'll take a task to make sure the build machines don't have unneeded packages installed.