### PR TITLE
Fix flaky data editor session tests by joining on the session's worker thread

### DIFF
--- a/tests/edit_data/test_data_editor_session.py
+++ b/tests/edit_data/test_data_editor_session.py
@@ -264,6 +264,7 @@ class TestDataEditorSession(unittest.TestCase):
 
         self._data_editor_session._is_initialized = True
         self._data_editor_session.commit_edit(self._connection, success_callback, mock.MagicMock())
+        self._data_editor_session._commit_task.join()
 
         self.assertTrue(len(self._data_editor_session._session_cache) is 0)
 
@@ -359,6 +360,7 @@ class TestDataEditorSession(unittest.TestCase):
 
         self._data_editor_session._is_initialized = True
         self._data_editor_session.commit_edit(self._connection, mock.MagicMock(), mock.MagicMock())
+        self._data_editor_session._commit_task.join()
 
         row_delete.get_script.assert_not_called()
         self.assertFalse(bool(self._data_editor_session._session_cache))
@@ -381,6 +383,7 @@ class TestDataEditorSession(unittest.TestCase):
 
         self._data_editor_session._is_initialized = True
         self._data_editor_session.commit_edit(self._connection, mock.MagicMock(), mock.MagicMock())
+        self._data_editor_session._commit_task.join()
 
         row_delete.get_script.assert_called_once()
         self.assertFalse(bool(self._data_editor_session._session_cache))


### PR DESCRIPTION
These tests were intermittently failing for our daily builds (e.g. http://xplat-build-vm:8080/job/pgtoolsservice-linux/301/) because they kicked off a thread but didn't wait for it to terminate before verifying its results.