### PR TITLE
PG- Query execution Bug Fixes

### DIFF
--- a/pgsqltoolsservice/query/batch.py
+++ b/pgsqltoolsservice/query/batch.py
@@ -139,6 +139,9 @@ class Batch:
         result_set.read_result_to_end(cursor)
         self._result_set = result_set
 
+    def get_subset(self, start_index: int, end_index: int):
+        return self._result_set.get_subset(start_index, end_index)
+
 
 class SelectBatch(Batch):
 

--- a/pgsqltoolsservice/query/data_storage/service_buffer.py
+++ b/pgsqltoolsservice/query/data_storage/service_buffer.py
@@ -10,7 +10,6 @@ class ServiceBufferFileStream:
 
     def __init__(self, stream: io.BufferedIOBase) -> None:
         self._file_stream = stream
-        self._close_stream_flag = False
 
     def __enter__(self):
         return self

--- a/pgsqltoolsservice/query/data_storage/service_buffer_file_stream_reader.py
+++ b/pgsqltoolsservice/query/data_storage/service_buffer_file_stream_reader.py
@@ -50,9 +50,8 @@ class ServiceBufferFileStreamReader(ServiceBufferFileStream):
         results = []  # list of DbCellValue as return
 
         for index in range(0, len_columns_info):
-            self._close_stream_flag = (index == len_columns_info - 1)
 
-            type_value = columns_info[index].data_type_name
+            type_value = columns_info[index].data_type
 
             # Read the object from the temp file
             if type_value == datatypes.DATATYPE_NULL:

--- a/pgsqltoolsservice/query/data_storage/storage_data_reader.py
+++ b/pgsqltoolsservice/query/data_storage/storage_data_reader.py
@@ -14,7 +14,7 @@ class StorageDataReader:
     def __init__(self, cursor) -> None:
         self._cursor = cursor
         self._current_row: tuple = None
-        self._columns_info = get_columns_info(cursor.description, cursor.connection)
+        self._columns_info = []
 
     @property
     def columns_info(self) -> List[DbColumn]:
@@ -28,6 +28,8 @@ class StorageDataReader:
         row_found = False
 
         for row in self._cursor:
+            if self._current_row is None:
+                self._columns_info = get_columns_info(self._cursor.description, self._cursor.connection)
             self._current_row = row
             row_found = True
             break

--- a/pgsqltoolsservice/query/file_storage_result_set.py
+++ b/pgsqltoolsservice/query/file_storage_result_set.py
@@ -83,11 +83,12 @@ class FileStorageResultSet(ResultSet):
         storage_data_reader = StorageDataReader(cursor)
 
         with file_stream.get_writer(self._output_file_name) as writer:
-            self.columns_info = storage_data_reader.columns_info
 
             while storage_data_reader.read_row():
                 self._file_offsets.append(self._total_bytes_written)
                 self._total_bytes_written += writer.write_row(storage_data_reader)
+
+            self.columns_info = storage_data_reader.columns_info
 
     def _append_row_to_buffer(self, cursor):
 

--- a/pgsqltoolsservice/query/query.py
+++ b/pgsqltoolsservice/query/query.py
@@ -140,6 +140,12 @@ class Query:
             connection.autocommit = current_auto_commit_status
             self._execution_state = ExecutionState.EXECUTED
 
+    def get_subset(self, batch_index: int, start_index: int, end_index: int):
+        if batch_index < 0 or batch_index >= len(self._batches):
+            raise IndexError('Batch index cannot be less than 0 or greater than the number of batches')
+
+        return self._batches[batch_index].get_subset(start_index, end_index)
+
 
 def compute_selection_data_for_batches(batches: List[str], full_text: str) -> List[SelectionData]:
     # Map the starting index of each line to the line number

--- a/pgsqltoolsservice/query_execution/query_execution_service.py
+++ b/pgsqltoolsservice/query_execution/query_execution_service.py
@@ -219,9 +219,11 @@ class QueryExecutionService(object):
         request_context.send_response(self._get_result_subset(request_context, params))
 
     def _get_result_subset(self, request_context: RequestContext, params: SubsetParams) -> SubsetResult:
-        result_set_subset = ResultSetSubset.from_query_results(
-            self.query_results, params.owner_uri,
-            params.batch_index, params.result_set_index, params.rows_start_index,
+        query: Query = self.get_query(params.owner_uri)
+
+        result_set_subset = query.get_subset(
+            params.batch_index,
+            params.rows_start_index,
             params.rows_start_index + params.rows_count)
 
         return SubsetResult(result_set_subset)

--- a/tests/query/data_storage/test_service_buffer_file_stream_reader.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_reader.py
@@ -85,7 +85,7 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         test_columns_info = []
 
         col = DbColumn()
-        col.data_type_name = datatypes.DATATYPE_BOOL
+        col.data_type = datatypes.DATATYPE_BOOL
         test_columns_info.append(col)
 
         res = self._bool_reader.read_row(test_file_offset, test_row_id, test_columns_info)
@@ -97,7 +97,7 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         test_columns_info = []
 
         col = DbColumn()
-        col.data_type_name = datatypes.DATATYPE_REAL
+        col.data_type = datatypes.DATATYPE_REAL
         test_columns_info.append(col)
 
         res = self._float_reader1.read_row(test_file_offset, test_row_id, test_columns_info)
@@ -109,7 +109,7 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         test_columns_info = []
 
         col = DbColumn()
-        col.data_type_name = datatypes.DATATYPE_REAL
+        col.data_type = datatypes.DATATYPE_REAL
         test_columns_info.append(col)
 
         res = self._float_reader2.read_row(test_file_offset, test_row_id, test_columns_info)
@@ -121,13 +121,13 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         test_columns_info = []
 
         real_column1 = DbColumn()
-        real_column1.data_type_name = datatypes.DATATYPE_REAL
+        real_column1.data_type = datatypes.DATATYPE_REAL
         integer_column = DbColumn()
-        integer_column.data_type_name = datatypes.DATATYPE_INTEGER
+        integer_column.data_type = datatypes.DATATYPE_INTEGER
         text_column = DbColumn()
-        text_column.data_type_name = datatypes.DATATYPE_TEXT
+        text_column.data_type = datatypes.DATATYPE_TEXT
         real_column2 = DbColumn()
-        real_column2.data_type_name = datatypes.DATATYPE_REAL
+        real_column2.data_type = datatypes.DATATYPE_REAL
 
         test_columns_info.append(real_column1)
         test_columns_info.append(integer_column)

--- a/tests/query/data_storage/test_service_buffer_file_stream_writer.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_writer.py
@@ -19,14 +19,16 @@ import tests.utils as utils
 
 class TestServiceBufferFileStreamWriter(unittest.TestCase):
 
+    SIZE_BUFFER_LENGTH = 4
+
     def setUp(self):
 
         self._file_stream = io.BytesIO()
         self._writer = ServiceBufferFileStreamWriter(self._file_stream)
         self._cursor = utils.MockCursor([tuple([11, 22, 33]), tuple([55, 66, 77])])
 
-    def tearDown(self):
-        pass
+    def get_expected_length_with_additional_buffer_for_size(self, test_value_length: int):
+        return TestServiceBufferFileStreamWriter.SIZE_BUFFER_LENGTH + test_value_length
 
     def test_write_to_file(self):
         val = 5
@@ -48,7 +50,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(1, res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(1), res)
 
     def test_write_float(self):
         test_value = 123.456
@@ -60,7 +62,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(4, res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(4), res)
 
     def test_write_int(self):
         test_value = 123456
@@ -72,7 +74,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(4, res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(4), res)
 
     def test_write_decimal(self):
         test_val = Decimal(123)
@@ -84,7 +86,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_val)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(4, res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(4), res)
 
     def test_write_char(self):
         test_value = 'a'
@@ -96,7 +98,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(1, res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(1), res)
 
     def test_write_str(self):
         test_value = 'TestString'
@@ -108,7 +110,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_date(self):
         test_value = '2004/10/19'
@@ -120,7 +122,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_time(self):
         test_value = '10:23:54'
@@ -132,7 +134,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_time_with_timezone(self):
         test_value = '10:23:54+02'
@@ -144,7 +146,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_datetime(self):
         test_value = '2004/10/19 10:23:54'
@@ -156,7 +158,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_timedelta(self):
         test_value = '3 days 04:05:06'
@@ -168,7 +170,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
     def test_write_uuid(self):
         test_value = uuid.uuid4()
@@ -180,7 +182,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(36, res)  # UUID standard len is 36
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(36), res)  # UUID standard len is 36
 
     def test_write_bytea(self):
         test_value = memoryview(b'TestString')
@@ -192,7 +194,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value.tobytes()), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value.tobytes())), res)
 
     def test_write_json(self):
         test_value = {"Name": "TestName", "Schema": "TestSchema"}
@@ -204,7 +206,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_array(self):
         test_value = ["TestVal1", "TestVal2"]
@@ -216,7 +218,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_int4range(self):
         test_value = NumericRange(10, 20)
@@ -228,7 +230,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_tsrange(self):
         test_value = DateTimeRange("2014-06-08 12:12:45", "2016-07-06 14:12:08")
@@ -240,7 +242,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_tstzrange(self):
         test_value = DateTimeTZRange("2014-06-08 12:12:45+02", "2016-07-06 14:12:08+02")
@@ -252,7 +254,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_daterange(self):
         test_value = DateRange("2015-06-06", "2016-08-08")
@@ -264,7 +266,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(str(test_value)), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
 
     def test_write_udt(self):
         test_value = "TestUserDefinedTypes"
@@ -276,7 +278,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(len(test_value), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(test_value)), res)
 
 
 class MockType:
@@ -292,6 +294,7 @@ class MockStorageDataReader(MockType):
     def __init__(self, cursor, columns_info):
         self._cursor = cursor
         self.columns_info = columns_info
+        self.is_none = mock.Mock(return_value=False)
 
     def get_value(self, i):
         pass

--- a/tests/query/test_batch.py
+++ b/tests/query/test_batch.py
@@ -119,6 +119,18 @@ class TestBatch(unittest.TestCase):
         self.assertFalse(isinstance(batch, SelectBatch))
         self.assertTrue(isinstance(batch, Batch))
 
+    def test_get_subset(self):
+        expected_subset = []
+        batch = create_batch('select 1', 0, self._selection_data, self._batch_events, ResultSetStorageType.IN_MEMORY)
+        self._result_set.get_subset = mock.Mock(return_value=expected_subset)
+
+        batch._result_set = self._result_set
+
+        subset = batch.get_subset(0, 10)
+
+        self.assertEqual(expected_subset, subset)
+        self._result_set.get_subset.assert_called_once_with(0, 10)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR has fixes for:
1. Populating column info when actually description is available, once the cursor is read once.
2. Implementing get_subset in query, batch
3. Plugging through the get_subset in query execution service
4. Chri's changes to writer to store the length to read for each column
5. Unit tests