### PR TITLE
Add min/max versions for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Integration tests require a local config file that contains the options for conn
 ### Creating Integration Tests
 Integration tests can be inserted in line with our unit tests. The `tests.integration` module exports a `integration_test` decorator and a `get_connection` function that can be used in integration tests.
 
-To declare that a test is an integration test, mark it with the imported `@integration_test` decorator. This will automatically patch `psycopg2.connect` in your test to return the test database connection from your config file, and will let you use the `get_connection` function to retrieve that connection if you need it elsewhere. You can also use the `create_extra_test_database` function if your test needs additional databases.
+To declare that a test is an integration test, mark it with the imported `@integration_test` decorator. This will automatically patch `psycopg2.connect` in your test to return the test database connection from your config file, and will let you use the `get_connection` function to retrieve that connection if you need it elsewhere. You can optionally pass `min_version` and `max_version` integer arguments to the `@integration_test` decorator to make the test only run when connected to the specified versions of Postgres. You can also use the `create_extra_test_database` function if your test needs additional databases.
 
 Each integration test will run with its own database, which will be created before the test starts and dropped when the test ends.
 

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -5,6 +5,7 @@
 
 """Module containing the logic to set up integration tests with a database connection"""
 
+import functools
 import json
 import os
 from typing import List
@@ -13,19 +14,34 @@ import uuid
 import psycopg2
 
 
-def integration_test(test):
-    """Decorator used to indicate that a test is an integration test, giving it a connection"""
+def integration_test(min_version=None, max_version=None):
+    """
+    Decorator used to indicate that a test is an integration test, giving it a connection
 
-    def new_test(*args):
-        _ConnectionManager.current_test_is_integration_test = True
-        try:
-            _ConnectionManager.run_test(test, *args)
-        finally:
-            _ConnectionManager.current_test_is_integration_test = False
-            _ConnectionManager.drop_test_databases()
-    new_test.is_integration_test = True
-    new_test.__name__ = test.__name__
-    return new_test
+    :param min_version: The minimum server version, as an integer, for running the test (e.g. 90600 for 9.6.0)
+    :param max_version: The maximum server version, as an integer, for running the test (e.g. 90600 for 9.6.0)
+    """
+
+    # If the decorator is called without parentheses, the first argument will actually be the test function
+    test_function = None
+    if callable(min_version):
+        test_function = min_version
+        min_version = None
+
+    def integration_test_internal(test):
+        @functools.wraps(test)
+        def new_test(*args):
+            _ConnectionManager.current_test_is_integration_test = True
+            try:
+                _ConnectionManager.run_test(test, min_version, max_version, *args)
+            finally:
+                _ConnectionManager.current_test_is_integration_test = False
+                _ConnectionManager.drop_test_databases()
+        new_test.is_integration_test = True
+        new_test.__name__ = test.__name__
+        return new_test
+
+    return integration_test_internal if test_function is None else integration_test_internal(test_function)
 
 
 # Indicate that nose should not treat the decorator as its own test
@@ -72,11 +88,14 @@ class _ConnectionManager:
         return db_name
 
     @classmethod
-    def run_test(cls, test, *args):
+    def run_test(cls, test, min_version, max_version, *args):
         cls._create_test_databases()
         needs_setup = False
         for index, details in enumerate(cls._current_test_connection_detail_list):
             cls._in_progress_test_index = index
+            server_version = cls._maintenance_connections[index].server_version
+            if min_version is not None and server_version < min_version or max_version is not None and server_version > max_version:
+                continue
             try:
                 if needs_setup:
                     args[0].setUp()


### PR DESCRIPTION
This PR adds optional `min_version` and `max_version` parameters for the integration test decorator, which can be used to create integration tests that should only run when connected to certain versions of Postgres.