### PR TITLE
Fix tests failing in master

### DIFF
--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -44,10 +44,6 @@ def integration_test(min_version=None, max_version=None):
     return integration_test_internal if test_function is None else integration_test_internal(test_function)
 
 
-# Indicate that nose should not treat the decorator as its own test
-integration_test.__test__ = False
-
-
 def get_connection_details() -> dict:
     """
     Get connection details that can be used in integration tests. These details are formatted as a
@@ -62,6 +58,11 @@ def create_extra_test_database() -> str:
     automatically be dropped at the end of the test.
     """
     return _ConnectionManager.create_extra_database()
+
+
+# Indicate that nose should not treat these functions as their own tests
+integration_test.__test__ = False
+create_extra_test_database.__test__ = False
 
 
 class _ConnectionManager:

--- a/tests/query/test_batch.py
+++ b/tests/query/test_batch.py
@@ -79,7 +79,7 @@ class TestBatch(unittest.TestCase):
 
         self.assertTrue(isinstance(result_set, InMemoryResultSet))
 
-    def test_create__result_set_with_type_file_storage(self):
+    def test_create_result_set_with_type_file_storage(self):
         result_set = create_result_set(ResultSetStorageType.FILE_STORAGE, 1, 1)
 
         self.assertTrue(isinstance(result_set, FileStorageResultSet))
@@ -131,14 +131,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(expected_subset, subset)
         self._result_set.get_subset.assert_called_once_with(0, 10)
 
-    def test_batch_doesnot_call_close_on_cursor_when_not_executed(self):
-        self.create_and_execute_batch(Batch)
-
-        self._cursor.close.assert_not_called()
-
     def test_batch_calls_close_on_cursor_when_executed(self):
-        self._cursor.rowcount = 1
-
         self.create_and_execute_batch(Batch)
 
         self._cursor.close.assert_called_once()

--- a/tests/query_execution/test_query_execution_service.py
+++ b/tests/query_execution/test_query_execution_service.py
@@ -175,8 +175,8 @@ class TestQueryService(unittest.TestCase):
         self.query_execution_service._handle_execute_query_request(self.request_context, params)
         self.query_execution_service.owner_to_thread_map[params.owner_uri].join()
 
-        # Then the transaction gets rolled back, the cursor gets closed, and an error notification gets sent
-        self.cursor.close.assert_called_once()
+        # Then the transaction gets rolled back, the cursor does not get manually closed, and an error notification gets sent
+        self.cursor.close.assert_not_called()
         self.request_context.send_notification.assert_called()
 
         notification_calls = self.request_context.send_notification.mock_calls
@@ -362,10 +362,10 @@ class TestQueryService(unittest.TestCase):
         self.query_execution_service._handle_execute_query_request(self.request_context, params)
         self.query_execution_service.owner_to_thread_map[params.owner_uri].join()
 
-        # Then we executed the query, closed the cursor,
+        # Then we executed the query, did not manually call close,
         # did not call fetchall(), and cleared the notices
         self.cursor.execute.assert_called_once()
-        self.cursor.close.assert_called_once()
+        self.cursor.close.assert_not_called()
         self.cursor.fetchall.assert_not_called()
         self.assertEqual(self.connection.notices, [])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -161,6 +161,7 @@ class MockCursor:
         """Set up dummy results for query execution success"""
         self.connection.notices = ["NOTICE: foo", "DEBUG: bar"]
         self.description = []
+        self.rowcount = len(self._query_results) if self._query_results is not None else 0
 
     def execute_failure_side_effects(self, *args):
         """Set up dummy results and raise error for query execution failure"""


### PR DESCRIPTION
Some tests are failing in master because of the server-side cursor changes in #160. This fixes those failures, as well as some failures related to integration tests that happen when attempting to run only unit tests locally.