### PR TITLE
Fix struct and data out of range error on query execution

### DIFF
--- a/pgsqltoolsservice/converters/bytes_converter.py
+++ b/pgsqltoolsservice/converters/bytes_converter.py
@@ -18,11 +18,26 @@ def convert_bool(value: bool):
 
 
 def convert_float(value: float):
-    return bytearray(struct.pack("f", value))
+    return bytearray(struct.pack("d", value))
 
 
-def convert_int(value: int):
-    return bytearray(struct.pack("i", value))
+def convert_double(value: float):
+    return bytearray(struct.pack("d", value))
+
+
+def convert_short(value: int):
+    """ range of smallint in pg is the same with short in c, although python type is int, but need to pack in short format """
+    return bytearray(struct.pack("h", value))
+
+
+def convert_long(value: int):
+    """ range of integer in pg is the same with long in c, although python type is int, but need to pack in long format """
+    return bytearray(struct.pack("l", value))
+
+
+def convert_long_long(value: int):
+    """ range of bigint in pg is the same with long long in c, although python type is int, but need to pack in long long format """
+    return bytearray(struct.pack("q", value))
 
 
 def convert_decimal(value: decimal.Decimal):
@@ -94,10 +109,10 @@ def convert_daterange(value: DateRange):
 DATATYPE_WRITER_MAP = {
     datatypes.DATATYPE_BOOL: convert_bool,
     datatypes.DATATYPE_REAL: convert_float,
-    datatypes.DATATYPE_DOUBLE: convert_float,
-    datatypes.DATATYPE_SMALLINT: convert_int,
-    datatypes.DATATYPE_INTEGER: convert_int,
-    datatypes.DATATYPE_BIGINT: convert_int,
+    datatypes.DATATYPE_DOUBLE: convert_double,
+    datatypes.DATATYPE_SMALLINT: convert_short,
+    datatypes.DATATYPE_INTEGER: convert_long,
+    datatypes.DATATYPE_BIGINT: convert_long_long,
     datatypes.DATATYPE_NUMERIC: convert_decimal,
     datatypes.DATATYPE_CHAR: convert_char,
     datatypes.DATATYPE_VARCHAR: convert_str,
@@ -109,9 +124,9 @@ DATATYPE_WRITER_MAP = {
     datatypes.DATATYPE_TIMESTAMP_WITH_TIMEZONE: convert_datetime,
     datatypes.DATATYPE_INTERVAL: convert_timedelta,
     datatypes.DATATYPE_UUID: convert_uuid,
-    datatypes.DATATYPE_SMALLSERIAL: convert_int,
-    datatypes.DATATYPE_SERIAL: convert_int,
-    datatypes.DATATYPE_BIGSERIAL: convert_int,
+    datatypes.DATATYPE_SMALLSERIAL: convert_short,
+    datatypes.DATATYPE_SERIAL: convert_long,
+    datatypes.DATATYPE_BIGSERIAL: convert_long_long,
     datatypes.DATATYPE_MONEY: convert_str,
     datatypes.DATATYPE_BYTEA: convert_memoryview,
     datatypes.DATATYPE_ENUM: convert_str,

--- a/pgsqltoolsservice/converters/bytes_to_any_converters.py
+++ b/pgsqltoolsservice/converters/bytes_to_any_converters.py
@@ -25,12 +25,24 @@ def convert_bytes_to_float(value) -> float:
     return struct.unpack('d', value)[0]
 
 
-def convert_bytes_to_int(value) -> int:
-    return struct.unpack('i', value)[0]
+def convert_bytes_to_double(value) -> float:
+    return struct.unpack('d', value)[0]
+
+
+def convert_bytes_to_short(value) -> int:
+    return struct.unpack('h', value)[0]
+
+
+def convert_bytes_to_long(value) -> int:
+    return struct.unpack('l', value)[0]
+
+
+def convert_bytes_to_long_long(value) -> int:
+    return struct.unpack('q', value)[0]
 
 
 def convert_bytes_to_decimal(value) -> decimal.Decimal:
-    return struct.unpack("i", int(value))[0]
+    return struct.unpack("i", value)[0]
 
 
 def convert_bytes_to_char(value) -> str:
@@ -107,10 +119,10 @@ def convert_bytes_to_daterange(value) -> DateRange:
 DATATYPE_READER_MAP = {
     datatypes.DATATYPE_BOOL: convert_bytes_to_bool,
     datatypes.DATATYPE_REAL: convert_bytes_to_float,
-    datatypes.DATATYPE_DOUBLE: convert_bytes_to_float,
-    datatypes.DATATYPE_SMALLINT: convert_bytes_to_int,
-    datatypes.DATATYPE_INTEGER: convert_bytes_to_int,
-    datatypes.DATATYPE_BIGINT: convert_bytes_to_int,
+    datatypes.DATATYPE_DOUBLE: convert_bytes_to_double,
+    datatypes.DATATYPE_SMALLINT: convert_bytes_to_short,
+    datatypes.DATATYPE_INTEGER: convert_bytes_to_long,
+    datatypes.DATATYPE_BIGINT: convert_bytes_to_long_long,
     datatypes.DATATYPE_NUMERIC: convert_bytes_to_decimal,
     datatypes.DATATYPE_CHAR: convert_bytes_to_char,
     datatypes.DATATYPE_VARCHAR: convert_bytes_to_str,
@@ -122,9 +134,9 @@ DATATYPE_READER_MAP = {
     datatypes.DATATYPE_TIMESTAMP_WITH_TIMEZONE: convert_bytes_to_datetime,
     datatypes.DATATYPE_INTERVAL: convert_bytes_to_timedelta,
     datatypes.DATATYPE_UUID: convert_bytes_to_uuid,
-    datatypes.DATATYPE_SMALLSERIAL: convert_bytes_to_int,
-    datatypes.DATATYPE_SERIAL: convert_bytes_to_int,
-    datatypes.DATATYPE_BIGSERIAL: convert_bytes_to_int,
+    datatypes.DATATYPE_SMALLSERIAL: convert_bytes_to_short,
+    datatypes.DATATYPE_SERIAL: convert_bytes_to_long,
+    datatypes.DATATYPE_BIGSERIAL: convert_bytes_to_long_long,
     datatypes.DATATYPE_MONEY: convert_bytes_to_str,
     datatypes.DATATYPE_BYTEA: convert_bytes_to_memoryview,
     datatypes.DATATYPE_ENUM: convert_bytes_to_str,

--- a/tests/query/data_storage/test_service_buffer_file_stream_reader.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_reader.py
@@ -22,7 +22,9 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         self._bool_test_value = True
         self._float_test_value1 = 123.456
         self._float_test_value2 = 123.45600128173828
-        self._int_test_value = 123456
+        self._short_test_value = 12345
+        self._long_test_value = 1234567890
+        self._long_long_test_value = 123456789012
         self._str_test_value = "TestString"
         self._bytea_test_value = memoryview(b'TestString')
         self._dict_test_value = {"Ser,ver": " Tes'tS,,erver ", "Sche'ma": "TestSchema"}
@@ -53,6 +55,27 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         float_len_to_write2 = bytearray(struct.pack("i", float_len2))
         self._float_file_stream2.write(float_len_to_write2)
         self._float_file_stream2.write(float_val2)
+
+        self._short_file_stream = io.BytesIO()
+        short_val = bytearray(struct.pack("h", self._short_test_value))
+        short_len = len(short_val)
+        short_len_to_write = bytearray(struct.pack("i", short_len))
+        self._short_file_stream.write(short_len_to_write)
+        self._short_file_stream.write(short_val)
+
+        self._long_file_stream = io.BytesIO()
+        long_val = bytearray(struct.pack("l", self._long_test_value))
+        long_len = len(long_val)
+        long_len_to_write = bytearray(struct.pack("i", long_len))
+        self._long_file_stream.write(long_len_to_write)
+        self._long_file_stream.write(long_val)
+
+        self._long_long_file_stream = io.BytesIO()
+        long_long_val = bytearray(struct.pack("q", self._long_long_test_value))
+        long_long_len = len(long_long_val)
+        long_long_len_to_write = bytearray(struct.pack("i", long_long_len))
+        self._long_long_file_stream.write(long_long_len_to_write)
+        self._long_long_file_stream.write(long_long_val)
 
         self._bytea_file_stream = io.BytesIO()
         bytea_val = bytes(self._bytea_test_value)
@@ -107,7 +130,7 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         val0 = bytearray(struct.pack("d", self._float_test_value1))
         len0 = len(val0)
         len0_to_write = bytearray(struct.pack("i", len0))
-        val1 = bytearray(struct.pack("i", self._int_test_value))
+        val1 = bytearray(struct.pack("l", self._long_test_value))
         len1 = len(val1)
         len1_to_write = bytearray(struct.pack("i", len1))
         val2 = bytearray(self._str_test_value.encode())
@@ -294,7 +317,7 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
 
         res = self._multiple_cols_reader.read_row(test_file_offset, test_row_id, test_columns_info)
         self.assertEqual(self._float_test_value1, res[0].raw_object)
-        self.assertEqual(self._int_test_value, res[1].raw_object)
+        self.assertEqual(self._long_test_value, res[1].raw_object)
         self.assertEqual(self._str_test_value, res[2].raw_object)
         self.assertEqual(self._float_test_value2, res[3].raw_object)
 

--- a/tests/query/data_storage/test_service_buffer_file_stream_writer.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_writer.py
@@ -62,10 +62,34 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(4), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(8), res)
 
-    def test_write_int(self):
-        test_value = 123456
+    def test_write_double(self):
+        test_value = 12345678.90123456
+        test_columns_info = []
+        col = DbColumn()
+        col.data_type = datatypes.DATATYPE_DOUBLE
+        test_columns_info.append(col)
+        mock_storage_data_reader = MockStorageDataReader(self._cursor, test_columns_info)
+        mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
+
+        res = self._writer.write_row(mock_storage_data_reader)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(8), res)
+
+    def test_write_short(self):
+        test_value = 12345
+        test_columns_info = []
+        col = DbColumn()
+        col.data_type = datatypes.DATATYPE_SMALLINT
+        test_columns_info.append(col)
+        mock_storage_data_reader = MockStorageDataReader(self._cursor, test_columns_info)
+        mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
+
+        res = self._writer.write_row(mock_storage_data_reader)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(2), res)
+
+    def test_write_long(self):
+        test_value = 1234567890
         test_columns_info = []
         col = DbColumn()
         col.data_type = datatypes.DATATYPE_INTEGER
@@ -75,6 +99,18 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
 
         res = self._writer.write_row(mock_storage_data_reader)
         self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(4), res)
+
+    def test_write_long_long(self):
+        test_value = 123456789012
+        test_columns_info = []
+        col = DbColumn()
+        col.data_type = datatypes.DATATYPE_BIGINT
+        test_columns_info.append(col)
+        mock_storage_data_reader = MockStorageDataReader(self._cursor, test_columns_info)
+        mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
+
+        res = self._writer.write_row(mock_storage_data_reader)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(8), res)
 
     def test_write_decimal(self):
         test_val = Decimal(123)


### PR DESCRIPTION
This PR:

(1) Fix the issue [Query Execution throws struct.error](https://github.com/Microsoft/carbon/issues/2409)
and [Query execution throws argument out of range](https://github.com/Microsoft/carbon/issues/2389)
(2) Related Unit test change. 

Other issues will be addressed with separate PR.
