### PR TITLE
Fix range type data displayes in wrong format

### DIFF
--- a/pgsqltoolsservice/converters/bytes_converter.py
+++ b/pgsqltoolsservice/converters/bytes_converter.py
@@ -92,19 +92,35 @@ def convert_list(value: list):
 
 
 def convert_numericrange(value: NumericRange):
-    return bytearray(str(value).encode())
+    """ Serialize NumericRange object in "[lower,upper)" format before convert to bytearray """
+    lower_bound = "[" if value.lower_inc else "("
+    upper_bound = "]" if value.upper_inc else ")"
+    formatted_value_str = lower_bound + str(int(value.lower)) + "," + str(int(value.upper)) + upper_bound
+    return bytearray(formatted_value_str.encode())
 
 
 def convert_datetimerange(value: DateTimeRange):
-    return bytearray(str(value).encode())
+    """ Serialize DateTimeRange object in "[lower,upper)" format before convert to bytearray """
+    lower_bound = "[" if value.lower_inc else "("
+    upper_bound = "]" if value.upper_inc else ")"
+    formatted_value_str = lower_bound + str(value.lower.isoformat()) + "," + str(value.upper.isoformat()) + upper_bound
+    return bytearray(formatted_value_str.encode())
 
 
 def convert_datetimetzrange(value: DateTimeTZRange):
-    return bytearray(str(value).encode())
+    """ Serialize DateTimeTZRange object in "[lower,upper)" format before convert to bytearray """
+    lower_bound = "[" if value.lower_inc else "("
+    upper_bound = "]" if value.upper_inc else ")"
+    formatted_value_str = lower_bound + str(value.lower.isoformat()) + "," + str(value.upper.isoformat()) + upper_bound
+    return bytearray(formatted_value_str.encode())
 
 
 def convert_daterange(value: DateRange):
-    return bytearray(str(value).encode())
+    """ Serialize DateRange object in "[lower,upper)" format before convert to bytearray """
+    lower_bound = "[" if value.lower_inc else "("
+    upper_bound = "]" if value.upper_inc else ")"
+    formatted_value_str = lower_bound + str(value.lower.isoformat()) + "," + str(value.upper.isoformat()) + upper_bound
+    return bytearray(formatted_value_str.encode())
 
 
 DATATYPE_WRITER_MAP = {

--- a/pgsqltoolsservice/converters/bytes_to_any_converters.py
+++ b/pgsqltoolsservice/converters/bytes_to_any_converters.py
@@ -10,7 +10,6 @@ import struct
 import json
 
 from pgsqltoolsservice.parsers import datatypes
-from psycopg2.extras import NumericRange, DateTimeRange, DateTimeTZRange, DateRange
 
 
 DECODING_METHOD = 'utf-8'
@@ -92,28 +91,24 @@ def convert_bytes_to_list(value) -> list:
     return json.loads(value_str)
 
 
-def convert_bytes_to_numericrange(value) -> NumericRange:
-    value_str = value.decode(DECODING_METHOD)
-    value_str_list = value_str.replace("NumericRange(", "").split(",")
-    return NumericRange(int(value_str_list[0]), int(value_str_list[1]))
+def convert_bytes_to_numericrange_format_str(value) -> str:
+    """ Since we are not using the NumericRange object, so just convert bytes to str for UI consuming """
+    return convert_bytes_to_str(value)
 
 
-def convert_bytes_to_datetimerange(value) -> DateTimeRange:
-    value_str = value.decode(DECODING_METHOD)
-    value_str_list = value_str.replace("DateTimeRange(", "").replace("'", "").split(", ")
-    return DateTimeRange(value_str_list[0], value_str_list[1])
+def convert_bytes_to_datetimerange_format_str(value) -> str:
+    """ Since we are not using the DateTimeRange object, so just convert bytes to str for UI consuming """
+    return convert_bytes_to_str(value)
 
 
-def convert_bytes_to_datetimetzrange(value) -> DateTimeTZRange:
-    value_str = value.decode(DECODING_METHOD)
-    value_str_list = value_str.replace("DateTimeTZRange(", "").replace("'", "").split(", ")
-    return DateTimeTZRange(value_str_list[0], value_str_list[1])
+def convert_bytes_to_datetimetzrange_format_str(value) -> str:
+    """ Since we are not using the DateTimeTZRange object, so just convert bytes to str for UI consuming """
+    return convert_bytes_to_str(value)
 
 
-def convert_bytes_to_daterange(value) -> DateRange:
-    value_str = value.decode(DECODING_METHOD)
-    value_str_list = value_str.replace("DateRange(", "").replace("'", "").split(", ")
-    return DateRange(value_str_list[0], value_str_list[1])
+def convert_bytes_to_daterange_format_str(value) -> str:
+    """ Since we are not using the DateRange object, so just convert bytes to str for UI consuming """
+    return convert_bytes_to_str(value)
 
 
 DATATYPE_READER_MAP = {
@@ -155,12 +150,12 @@ DATATYPE_READER_MAP = {
     datatypes.DATATYPE_XML: convert_bytes_to_str,
     datatypes.DATATYPE_JSON: convert_bytes_to_dict,
     datatypes.DATATYPE_ARRAY: convert_bytes_to_list,
-    datatypes.DATATYPE_INT4RANGE: convert_bytes_to_numericrange,
-    datatypes.DATATYPE_INT8RANGE: convert_bytes_to_numericrange,
-    datatypes.DATATYPE_NUMRANGE: convert_bytes_to_numericrange,
-    datatypes.DATATYPE_TSRANGE: convert_bytes_to_datetimerange,
-    datatypes.DATATYPE_TSTZRANGE: convert_bytes_to_datetimetzrange,
-    datatypes.DATATYPE_DATERANGE: convert_bytes_to_daterange
+    datatypes.DATATYPE_INT4RANGE: convert_bytes_to_numericrange_format_str,
+    datatypes.DATATYPE_INT8RANGE: convert_bytes_to_numericrange_format_str,
+    datatypes.DATATYPE_NUMRANGE: convert_bytes_to_numericrange_format_str,
+    datatypes.DATATYPE_TSRANGE: convert_bytes_to_datetimerange_format_str,
+    datatypes.DATATYPE_TSTZRANGE: convert_bytes_to_datetimetzrange_format_str,
+    datatypes.DATATYPE_DATERANGE: convert_bytes_to_daterange_format_str
 }
 
 

--- a/tests/query/data_storage/test_service_buffer_file_stream_reader.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_reader.py
@@ -11,7 +11,6 @@ import json
 from pgsqltoolsservice.query.data_storage.service_buffer_file_stream_reader import ServiceBufferFileStreamReader
 from pgsqltoolsservice.query.contracts.column import DbColumn
 from pgsqltoolsservice.parsers import datatypes
-from psycopg2.extras import NumericRange, DateTimeRange, DateTimeTZRange, DateRange
 
 
 class TestServiceBufferFileStreamReader(unittest.TestCase):
@@ -29,10 +28,10 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         self._bytea_test_value = memoryview(b'TestString')
         self._dict_test_value = {"Ser,ver": " Tes'tS,,erver ", "Sche'ma": "TestSchema"}
         self._list_test_value = ["Test,Server", "Tes'tSchema", "Tes,'tTable"]
-        self._numericrange_test_value = NumericRange(10, 20)
-        self._datetimerange_test_value = DateTimeRange("2014-06-08 12:12:45", "2016-07-06 14:12:08")
-        self._datetimetzrange_test_value = DateTimeTZRange("2014-06-08 12:12:45+02", "2016-07-06 14:12:08+02")
-        self._daterange_test_value = DateRange("2015-06-06", "2016-08-08")
+        self._numericrange_test_value = "[10,20)"
+        self._datetimerange_test_value = "[2014-06-08T12:12:45,2016-07-06T14:12:08)"
+        self._datetimetzrange_test_value = "[2014-06-08T12:12:45-07:00,2016-07-06T14:12:08-07:00)"
+        self._daterange_test_value = "[2015-06-06,2016-08-08)"
 
         # file_streams
         self._bool_file_stream = io.BytesIO()

--- a/tests/query/data_storage/test_service_buffer_file_stream_writer.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_writer.py
@@ -10,6 +10,7 @@ import uuid
 import struct
 import io
 import datetime
+import psycopg2
 from psycopg2.extras import NumericRange, DateTimeRange, DateTimeTZRange, DateRange
 
 from pgsqltoolsservice.query.data_storage.service_buffer_file_stream_writer import ServiceBufferFileStreamWriter
@@ -267,10 +268,10 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len("[10,20)")), res)
 
     def test_write_tsrange(self):
-        test_value = DateTimeRange("2014-06-08 12:12:45", "2016-07-06 14:12:08")
+        test_value = DateTimeRange(datetime.datetime(2014, 6, 8, 12, 12, 45), datetime.datetime(2016, 7, 6, 14, 12, 8))
         test_columns_info = []
         col = DbColumn()
         col.data_type = datatypes.DATATYPE_TSRANGE
@@ -279,10 +280,11 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len("[2014-06-08T12:12:45,2016-07-06T14:12:08)")), res)
 
     def test_write_tstzrange(self):
-        test_value = DateTimeTZRange("2014-06-08 12:12:45+02", "2016-07-06 14:12:08+02")
+        test_value = DateTimeTZRange(datetime.datetime(2014, 6, 8, 12, 12, 45, tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=720, name=None)),
+                                     datetime.datetime(2016, 7, 6, 14, 12, 8, tzinfo=psycopg2.tz.FixedOffsetTimezone(offset=720, name=None)))
         test_columns_info = []
         col = DbColumn()
         col.data_type = datatypes.DATATYPE_TSTZRANGE
@@ -291,10 +293,10 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len("[2014-06-08T12:12:45+12:00,2016-07-06T14:12:08+12:00)")), res)
 
     def test_write_daterange(self):
-        test_value = DateRange("2015-06-06", "2016-08-08")
+        test_value = DateRange(datetime.date(2015, 6, 6), datetime.date(2016, 8, 8))
         test_columns_info = []
         col = DbColumn()
         col.data_type = datatypes.DATATYPE_DATERANGE
@@ -303,7 +305,7 @@ class TestServiceBufferFileStreamWriter(unittest.TestCase):
         mock_storage_data_reader.get_value = mock.MagicMock(return_value=test_value)
 
         res = self._writer.write_row(mock_storage_data_reader)
-        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len(str(test_value))), res)
+        self.assertEqual(self.get_expected_length_with_additional_buffer_for_size(len("[2015-06-06,2016-08-08)")), res)
 
     def test_write_udt(self):
         test_value = "TestUserDefinedTypes"


### PR DESCRIPTION
This PR includes:

(1) Fix on this issue: [Int4range type data is displayed in wrong format ](https://github.com/Microsoft/carbon/issues/2407)
(2) Fix on TSRANGE, TSTZRANGE and DATERANGE type of data has wrong format which displayed on Carbon UI.
(3) Related unit test changes.