### PR TITLE
try pyscopg2.connect with valid parameters and avoid extra parameters

### DIFF
--- a/pgsqltoolsservice/connection/connection_service.py
+++ b/pgsqltoolsservice/connection/connection_service.py
@@ -118,7 +118,7 @@ class ConnectionService:
 
         # Map the connection options to their psycopg2-specific options
         connection_options = {CONNECTION_OPTION_KEY_MAP.get(option, option): value for option, value in params.connection.options.items()
-                              if option in PYSCOPG2_CONNECTION_PARAMETERS}
+                              if option in PG_CONNECTION_PARAM_KEYWORDS}
 
         # Use the default database if one was not provided
         if 'dbname' not in connection_options or not connection_options['dbname']:
@@ -355,7 +355,9 @@ CONNECTION_OPTION_KEY_MAP = {
     'applicationName': 'application_name'
 }
 
-PYSCOPG2_CONNECTION_PARAMETERS = [
+# Recognized parameter keywords for postgres database connection
+# Source: https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+PG_CONNECTION_PARAM_KEYWORDS = [
     'host', 'hostaddr', 'port', 'dbname', 'user', 'password', 'passfile', 'connect_timeout',
     'client_encoding', 'options', 'application_name', 'fallback_application_name', 'keepalives',
     'keepalives_idle', 'keepalives_interval', 'keepalives_count', 'tty', 'sslmode', 'requiressl',


### PR DESCRIPTION
This change is to avoid connection errors if some extra connection options exist. For example Carbon started sending groupId in params for connection which psycopg2.conenct does not recognize.
Fixes [bug](https://github.com/Microsoft/carbon/issues/2873)