### PR TITLE
added convalidated column in select similar to 9.6 ver script

### DIFF
--- a/pgsmo/objects/table_objects/constraint_check/+default/nodes.sql
+++ b/pgsmo/objects/table_objects/constraint_check/+default/nodes.sql
@@ -4,7 +4,8 @@
  # Copyright (C) 2013 - 2017, The pgAdmin Development Team
  # This software is released under the PostgreSQL Licence
  #}
-SELECT c.oid, conname as name
+SELECT c.oid, conname as name,
+    NOT convalidated as convalidated
     FROM pg_constraint c
 WHERE contype = 'c'
 {% if tid %}


### PR DESCRIPTION
Fixes [bug](https://github.com/Microsoft/carbon/issues/2904)

Added "convalidated" column in postgres default version nodes script.  The _convalidated property is required while constructing constraint class from query.(_from_node_query)