### PR TITLE
Force cx freeze to use version 5.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ prompt_toolkit
 jinja2
 
 # Build/Test Requirements
-cx_freeze
+cx_freeze==5.0.2
 nose
 parameterized
 coverage


### PR DESCRIPTION
Chris discovered that our build packaging system broke, and it seems to be because cx_freeze updated to version 5.1 and we will need to make config changes to work with it.

For now we'll just continue to use the old version, 5.0.2, which seems to work fine.