### PR TITLE
Fix query 'unpack requires a bytes object of length 8' bug

### DIFF
--- a/pgsqltoolsservice/query/data_storage/service_buffer_file_stream_writer.py
+++ b/pgsqltoolsservice/query/data_storage/service_buffer_file_stream_writer.py
@@ -59,6 +59,8 @@ class ServiceBufferFileStreamWriter(ServiceBufferFileStream):
 
             # Write the object into the temp file
             if reader.is_none(index):
+                # if it's a NULL value, the bytes length to write is 0
+                row_bytes += self._write_to_file(self._file_stream, bytearray(struct.pack("i", 0)))
                 row_bytes += self._write_null()
             else:
                 bytes_converter: Callable[[str], bytearray] = get_bytes_converter(type_value)


### PR DESCRIPTION
This PR:

(1) Fixing this bug: [Error on query execution "unpack requires a bytes object of length 8"](https://github.com/Microsoft/carbon/issues/3092).
The root cause which the error happened is the NULL value was not taken care properly. It leads to a wrong status of ServiceBufferFileStreamReader.
