### PR TITLE
Add ability for service to accept azureAccountToken from ADS client

### DIFF
--- a/pgsqltoolsservice/capabilities/capabilities_service.py
+++ b/pgsqltoolsservice/capabilities/capabilities_service.py
@@ -81,6 +81,16 @@ class CapabilitiesService:
                 group_name='Security'
             ),
             ConnectionOption(
+                name='azureAccountToken',
+                display_name='Access Token',
+                description='Indicates an Active Directory access token to be used when connecting to the data source',
+                value_type=ConnectionOption.VALUE_TYPE_ACCESS_TOKEN,
+                special_value_type=ConnectionOption.SPECIAL_VALUE_ACCESS_TOKEN_NAME,
+                is_identity=True,
+                is_required=False,
+                group_name='Security'
+            ),
+            ConnectionOption(
                 name='hostaddr',
                 display_name='Host IP address',
                 description='IP address of the server',

--- a/pgsqltoolsservice/capabilities/contracts/capabilities_request.py
+++ b/pgsqltoolsservice/capabilities/contracts/capabilities_request.py
@@ -29,6 +29,7 @@ class ServiceOption:
     VALUE_TYPE_STRING = 'string'
     VALUE_TYPE_MULTI_STRING = 'multistring'
     VALUE_TYPE_PASSWORD = 'password'
+    VALUE_TYPE_ACCESS_TOKEN = 'azureAccountToken'
     VALUE_TYPE_NUMBER = 'number'
     VALUE_TYPE_CATEGORY = 'category'
     VALUE_TYPE_BOOLEAN = 'boolean'
@@ -52,6 +53,7 @@ class ConnectionOption(ServiceOption):
     SPECIAL_VALUE_AUTH_TYPE = 'authType'
     SPECIAL_VALUE_USER_NAME = 'userName'
     SPECIAL_VALUE_PASSWORD_NAME = 'password'
+    SPECIAL_VALUE_ACCESS_TOKEN_NAME = 'azureAccountToken'
     SPECIAL_VALUE_APP_NAME = 'appName'
 
     def __init__(self, name: str = None, display_name: str = None, description: str = None, group_name: str = None, value_type: str = None,

--- a/pgsqltoolsservice/connection/connection_service.py
+++ b/pgsqltoolsservice/connection/connection_service.py
@@ -120,6 +120,11 @@ class ConnectionService:
                 self._cancellation_map[cancellation_key].cancel()
             self._cancellation_map[cancellation_key] = cancellation_token
 
+        # If options contains azureSecurityToken, then just copy it over to password, which is how it is
+        # passed to PostgreSQL.
+        if params.connection.options['azureAccountToken']:
+            params.connection.options['password'] = params.connection.options['azureAccountToken']
+
         # Map the connection options to their psycopg2-specific options
         connection_options = {CONNECTION_OPTION_KEY_MAP.get(option, option): value for option, value in params.connection.options.items()
                               if option in PG_CONNECTION_PARAM_KEYWORDS}

--- a/pgsqltoolsservice/connection/connection_service.py
+++ b/pgsqltoolsservice/connection/connection_service.py
@@ -122,7 +122,7 @@ class ConnectionService:
 
         # If options contains azureSecurityToken, then just copy it over to password, which is how it is
         # passed to PostgreSQL.
-        if params.connection.options['azureAccountToken']:
+        if 'azureAccountToken' in params.connection.options:
             params.connection.options['password'] = params.connection.options['azureAccountToken']
 
         # Map the connection options to their psycopg2-specific options

--- a/tests/connection/test_connection_service.py
+++ b/tests/connection/test_connection_service.py
@@ -813,14 +813,13 @@ class TestConnectionCancellation(unittest.TestCase):
     def test_connect_with_access_token(self):
         """Test that the service connects to a PostgreSQL server using an access token as a password"""
         # Set up the parameters for the connection
-        exampleToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6InBMRGUwU2JIT2xUN0JMUmt6ZzdERGpSUmRnbyIsImtpZCI6InBMRGUwU2JIT2xUN0JMUmt6ZzdERGpSUmRnbyJ9.eyJhdWQiOiJodHRwczovL29zc3JkYm1zLWFhZC5kYXRhYmFzZS5tc2Nkcy5jb20iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLXBwZS5uZXQvMzg2NzdlOTgtNTk1YS00M2ZhLTg2YTctMGRmOTJhMDIyOTUzLyIsImlhdCI6MTU3OTY0Mjk4MSwibmJmIjoxNTc5NjQyOTgxLCJleHAiOjE1Nzk2NDY4ODEsImFjciI6IjEiLCJhaW8iOiJFMlJnWUlnKzVMeTA3ZU5zZDZIOE8xK2ZUZFF0bnNGUks2WFpsOER1OEpEMTRhbk90QndBIiwiYW1yIjpbInB3ZCJdLCJhcHBpZCI6IjNlYjlhNTI3LTFiMTktNDNlNi04YTYxLWM5NDRhNWQxM2IzMiIsImFwcGlkYWNyIjoiMCIsImdyb3VwcyI6WyI1MjUzNTM4OS1jODFkLTQ0NjItOWE4ZC0wNTMwZjEyOGU1YTciLCIxMDE0MTQ4OC1hMmU4LTRlMzEtYTQ0ZS1iOGM1MmMyNWVjZDgiXSwiaXBhZGRyIjoiNjkuMTgxLjEyMi4xMCIsIm5hbWUiOiJDaGFybGllIEJyb3duIiwib2lkIjoiMGE4NDFmOGEtZDc5Yi00NmY1LThiZjItMTljMGRmMjE1NWI0IiwicHVpZCI6IjEwMDNERkZEMDAwMURFMjIiLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJDOWRaV2cyUlplRzNZOFlfZlFsbEpsN0t1VXc2R3o2N2QtZEtxVUx0ZGlnIiwidGlkIjoiMzg2NzdlOTgtNTk1YS00M2ZhLTg2YTctMGRmOTJhMDIyOTUzIiwidW5pcXVlX25hbWUiOiJjYnJvd25Ab3JjYXNhYWR0ZXN0LmNjc2N0cC5uZXQiLCJ1cG4iOiJjYnJvd25Ab3JjYXNhYWR0ZXN0LmNjc2N0cC5uZXQiLCJ1dGkiOiJ6LXQtQTJMOTRVQ2t1bkVkVENFREFBIiwidmVyIjoiMS4wIn0.j4Qh6tIuwRoY58iXUFd5ndJQPPHCs8ANf93pl6LqHPdo-gbTuCatXf7CWT1ehuWDNIvgAlwdn7G-tjs1Y5RDJU38cwDUCOTVrqUJWS-a02E2yCtJUgq_ZGicQ7K0BPO2ebAzszUkKM_vIlC9o2xKWsGhJz5UuRn_J3-esZk-crxl9472sJb55WXerizk-X1OhlKIKaRv14zvxRECt0z-5ks3Ozwe8uOgWnWqGVdGXzzbEroDW3LKVL2reSt7BVhfTgnQtKa9hBr3BY5f_x5iVYUq8XK2fYddGdY-Zfpnc8UK2rpbqe4sVfjJQ8MdfCR4ftw99U-F36IM95rCtXFEvw'
         params: ConnectRequestParams = ConnectRequestParams.from_dict({
             'ownerUri': 'someUri',
             'type': ConnectionType.DEFAULT,
             'connection': {
                 'options': {
                     'user': 'postgres',
-                    'azureAccountToken': exampleToken,
+                    'azureAccountToken': 'exampleToken',
                     'host': 'myserver',
                     'dbname': 'postgres'
                 }
@@ -835,14 +834,22 @@ class TestConnectionCancellation(unittest.TestCase):
         })
 
         # Set up psycopg2 instance for connection service to call
-        mock_connect_method = mock.Mock(return_value = mock_connection);
+        mock_connect_method = mock.Mock(return_value=mock_connection)
 
         # Set up the connection service and call its connect method with the supported options
         with mock.patch('psycopg2.connect', new=mock_connect_method):
             response = self.connection_service.connect(params)
 
         # Verify that psycopg2's connection method was called with password set to account token.
-        mock_connect_method.assert_called_once_with(user='postgres', password=exampleToken, host='myserver', dbname='postgres')
+        mock_connect_method.assert_called_once_with(user='postgres', password='exampleToken', host='myserver', dbname='postgres')
+
+        # Verify that psycopg2's connection method was called and that the
+        # response has a connection id, indicating success.
+        self.assertIs(self.connection_service.owner_to_connection_map[params.owner_uri].get_connection(params.type),
+                      mock_connection)
+        self.assertIsNotNone(response.connection_id)
+        self.assertIsNotNone(response.server_info.server_version)
+        self.assertFalse(response.server_info.is_cloud)
 
     def _mock_connect(self, **kwargs):
         """Implementation for the mock psycopg2.connect method that saves the current cancellation token"""

--- a/tests/connection/test_connection_service.py
+++ b/tests/connection/test_connection_service.py
@@ -23,7 +23,7 @@ from pgsqltoolsservice.utils.cancellation import CancellationToken
 from pgsqltoolsservice.workspace import WorkspaceService
 from tests.integration import get_connection_details, integration_test
 import tests.utils as utils
-from tests.utils import MockPsycopg2, MockConnection, MockCursor, MockRequestContext
+from tests.utils import MockConnection, MockCursor, MockRequestContext
 
 
 class TestConnectionService(unittest.TestCase):


### PR DESCRIPTION
ADS sends azureAccountToken (instead of password) for Azure Active Directory login. PostgreSQL for Azure wire protocol takes the access token in place of a password for AAD users. 

So, a) accept azureAccountToken as a connection parameter, and b) send it as a password to PostgreSQL.