### PR TITLE
Fix for skipping intellisense for non pgsql language flavor

### DIFF
--- a/pgsqltoolsservice/language/language_service.py
+++ b/pgsqltoolsservice/language/language_service.py
@@ -142,11 +142,12 @@ class LanguageService:
         def do_send_default_empty_response():
             request_context.send_response(response)
 
-        if self.should_skip_intellisense(params.text_document.uri):
-            do_send_default_empty_response()
-            return
         script_file: ScriptFile = self._workspace_service.workspace.get_file(params.text_document.uri)
         if script_file is None:
+            do_send_default_empty_response()
+            return
+
+        if self.should_skip_intellisense(script_file.file_uri):
             do_send_default_empty_response()
             return
 


### PR DESCRIPTION
We are directly using the text document uri which is encoded, hence now using the decoded url which is by using file_url from script file.

Similar fix to mssql extension: https://github.com/microsoft/sqltoolsservice/pull/910