### PR TITLE
Adding apis for deploying a project

### DIFF
--- a/pgsqltoolsservice/query_execution/contracts/__init__.py
+++ b/pgsqltoolsservice/query_execution/contracts/__init__.py
@@ -49,10 +49,10 @@ from pgsqltoolsservice.query_execution.contracts.save_result_as_request import (
 
 __all__ = [
     'BatchNotificationParams',
-    'BATCH_START_NOTIFICATION', 'BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_START_NOTIFICATION'
+    'BATCH_START_NOTIFICATION', 'BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_START_NOTIFICATION',
     'ExecuteDocumentSelectionParams', 'ExecuteStringParams', 'ExecuteRequestParamsBase',
-    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST', 'EXECUTE_DEPLOY_STRING_REQUEST'
-    'MessageNotificationParams', 'MESSAGE_NOTIFICATION', 'MESSAGE_DEPLOY_NOTIFICATION', 'QueryCompleteNotificationParams',
+    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST', 'EXECUTE_DEPLOY_STRING_REQUEST',
+    'MessageNotificationParams', 'MESSAGE_NOTIFICATION', 'DEPLOY_MESSAGE_NOTIFICATION', 'QueryCompleteNotificationParams',
     'QUERY_COMPLETE_NOTIFICATION', 'DEPLOY_COMPLETE_NOTIFICATION', 'ResultMessage', 'ResultSetNotificationParams',
     'RESULT_SET_AVAILABLE_NOTIFICATION', 'RESULT_SET_COMPLETE_NOTIFICATION', 'RESULT_SET_UPDATED_NOTIFICATION',
     'SubsetParams', 'SUBSET_REQUEST', 'CANCEL_REQUEST', 'QueryCancelResult', 'QueryCancelParams',

--- a/pgsqltoolsservice/query_execution/contracts/__init__.py
+++ b/pgsqltoolsservice/query_execution/contracts/__init__.py
@@ -11,7 +11,7 @@ from pgsqltoolsservice.query_execution.contracts.batch_notification import (
 from pgsqltoolsservice.query_execution.contracts.execute_request import (
     ExecuteDocumentSelectionParams, ExecuteStringParams, ExecuteRequestParamsBase,
     ExecuteResult, ExecutionPlanOptions, EXECUTE_DOCUMENT_SELECTION_REQUEST,
-    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_STRING_REQUEST,
+    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_REQUEST,
     ExecuteDocumentStatementParams, EXECUTE_DOCUMENT_STATEMENT_REQUEST
 )
 from pgsqltoolsservice.query_execution.contracts.query_request import (
@@ -51,7 +51,7 @@ __all__ = [
     'BatchNotificationParams',
     'BATCH_START_NOTIFICATION', 'BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_START_NOTIFICATION',
     'ExecuteDocumentSelectionParams', 'ExecuteStringParams', 'ExecuteRequestParamsBase',
-    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST', 'EXECUTE_DEPLOY_STRING_REQUEST',
+    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST', 'EXECUTE_DEPLOY_REQUEST',
     'MessageNotificationParams', 'MESSAGE_NOTIFICATION', 'DEPLOY_MESSAGE_NOTIFICATION', 'QueryCompleteNotificationParams',
     'QUERY_COMPLETE_NOTIFICATION', 'DEPLOY_COMPLETE_NOTIFICATION', 'ResultMessage', 'ResultSetNotificationParams',
     'RESULT_SET_AVAILABLE_NOTIFICATION', 'RESULT_SET_COMPLETE_NOTIFICATION', 'RESULT_SET_UPDATED_NOTIFICATION',

--- a/pgsqltoolsservice/query_execution/contracts/__init__.py
+++ b/pgsqltoolsservice/query_execution/contracts/__init__.py
@@ -5,11 +5,13 @@
 
 from pgsqltoolsservice.query_execution.contracts.batch_notification import (
     BatchNotificationParams,
-    BATCH_COMPLETE_NOTIFICATION, BATCH_START_NOTIFICATION
+    BATCH_COMPLETE_NOTIFICATION, BATCH_START_NOTIFICATION,
+    DEPLOY_BATCH_COMPLETE_NOTIFICATION, DEPLOY_BATCH_START_NOTIFICATION
 )
 from pgsqltoolsservice.query_execution.contracts.execute_request import (
     ExecuteDocumentSelectionParams, ExecuteStringParams, ExecuteRequestParamsBase,
-    ExecuteResult, ExecutionPlanOptions, EXECUTE_DOCUMENT_SELECTION_REQUEST, EXECUTE_STRING_REQUEST,
+    ExecuteResult, ExecutionPlanOptions, EXECUTE_DOCUMENT_SELECTION_REQUEST,
+    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_STRING_REQUEST,
     ExecuteDocumentStatementParams, EXECUTE_DOCUMENT_STATEMENT_REQUEST
 )
 from pgsqltoolsservice.query_execution.contracts.query_request import (
@@ -19,11 +21,13 @@ from pgsqltoolsservice.query_execution.contracts.query_request import (
 from pgsqltoolsservice.query_execution.contracts.message_notification import (
     ResultMessage,
     MessageNotificationParams,
-    MESSAGE_NOTIFICATION
+    MESSAGE_NOTIFICATION,
+    DEPLOY_MESSAGE_NOTIFICATION
 )
 from pgsqltoolsservice.query_execution.contracts.query_complete_notification import (
     QueryCompleteNotificationParams,
-    QUERY_COMPLETE_NOTIFICATION
+    QUERY_COMPLETE_NOTIFICATION,
+    DEPLOY_COMPLETE_NOTIFICATION
 )
 from pgsqltoolsservice.query_execution.contracts.result_set_notification import (
     ResultSetNotificationParams,
@@ -45,11 +49,11 @@ from pgsqltoolsservice.query_execution.contracts.save_result_as_request import (
 
 __all__ = [
     'BatchNotificationParams',
-    'BATCH_START_NOTIFICATION', 'BATCH_COMPLETE_NOTIFICATION',
+    'BATCH_START_NOTIFICATION', 'BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_COMPLETE_NOTIFICATION', 'DEPLOY_BATCH_START_NOTIFICATION'
     'ExecuteDocumentSelectionParams', 'ExecuteStringParams', 'ExecuteRequestParamsBase',
-    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST',
-    'MessageNotificationParams', 'MESSAGE_NOTIFICATION', 'QueryCompleteNotificationParams',
-    'QUERY_COMPLETE_NOTIFICATION', 'ResultMessage', 'ResultSetNotificationParams',
+    'ExecuteResult', 'ExecutionPlanOptions', 'EXECUTE_DOCUMENT_SELECTION_REQUEST', 'EXECUTE_STRING_REQUEST', 'EXECUTE_DEPLOY_STRING_REQUEST'
+    'MessageNotificationParams', 'MESSAGE_NOTIFICATION', 'MESSAGE_DEPLOY_NOTIFICATION', 'QueryCompleteNotificationParams',
+    'QUERY_COMPLETE_NOTIFICATION', 'DEPLOY_COMPLETE_NOTIFICATION', 'ResultMessage', 'ResultSetNotificationParams',
     'RESULT_SET_AVAILABLE_NOTIFICATION', 'RESULT_SET_COMPLETE_NOTIFICATION', 'RESULT_SET_UPDATED_NOTIFICATION',
     'SubsetParams', 'SUBSET_REQUEST', 'CANCEL_REQUEST', 'QueryCancelResult', 'QueryCancelParams',
     'QueryDisposeParams', 'QUERY_EXECUTION_PLAN_REQUEST', 'QueryExecutionPlanRequest', 'DISPOSE_REQUEST',

--- a/pgsqltoolsservice/query_execution/contracts/batch_notification.py
+++ b/pgsqltoolsservice/query_execution/contracts/batch_notification.py
@@ -24,3 +24,7 @@ class BatchNotificationParams:
 BATCH_COMPLETE_NOTIFICATION = 'query/batchComplete'
 
 BATCH_START_NOTIFICATION = 'query/batchStart'
+
+DEPLOY_BATCH_COMPLETE_NOTIFICATION = 'query/deployBatchComplete'
+
+DEPLOY_BATCH_START_NOTIFICATION = 'query/deployBatchStart'

--- a/pgsqltoolsservice/query_execution/contracts/execute_request.py
+++ b/pgsqltoolsservice/query_execution/contracts/execute_request.py
@@ -36,6 +36,11 @@ EXECUTE_STRING_REQUEST = IncomingMessageConfiguration(
     ExecuteStringParams
 )
 
+EXECUTE_DEPLOY_STRING_REQUEST = IncomingMessageConfiguration(
+    'query/executeDeployString',
+    ExecuteStringParams
+)
+
 
 class ExecuteDocumentSelectionParams(ExecuteRequestParamsBase):
     @classmethod

--- a/pgsqltoolsservice/query_execution/contracts/execute_request.py
+++ b/pgsqltoolsservice/query_execution/contracts/execute_request.py
@@ -36,8 +36,8 @@ EXECUTE_STRING_REQUEST = IncomingMessageConfiguration(
     ExecuteStringParams
 )
 
-EXECUTE_DEPLOY_STRING_REQUEST = IncomingMessageConfiguration(
-    'query/executeDeployString',
+EXECUTE_DEPLOY_REQUEST = IncomingMessageConfiguration(
+    'query/executeDeploy',
     ExecuteStringParams
 )
 

--- a/pgsqltoolsservice/query_execution/contracts/message_notification.py
+++ b/pgsqltoolsservice/query_execution/contracts/message_notification.py
@@ -27,3 +27,5 @@ class MessageNotificationParams:
 
 
 MESSAGE_NOTIFICATION = 'query/message'
+
+DEPLOY_MESSAGE_NOTIFICATION = 'query/deployMessage'

--- a/pgsqltoolsservice/query_execution/contracts/query_complete_notification.py
+++ b/pgsqltoolsservice/query_execution/contracts/query_complete_notification.py
@@ -22,3 +22,5 @@ class QueryCompleteNotificationParams:
 
 
 QUERY_COMPLETE_NOTIFICATION = 'query/complete'
+
+DEPLOY_COMPLETE_NOTIFICATION = 'query/deployComplete'

--- a/pgsqltoolsservice/query_execution/query_execution_service.py
+++ b/pgsqltoolsservice/query_execution/query_execution_service.py
@@ -21,7 +21,7 @@ from pgsqltoolsservice.query import (
 from pgsqltoolsservice.query.contracts import BatchSummary, ResultSetSubset, SelectionData, SaveResultsRequestParams, SubsetResult  # noqa
 from pgsqltoolsservice.query import ResultSetStorageType
 from pgsqltoolsservice.query_execution.contracts import (
-    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_STRING_REQUEST, EXECUTE_DOCUMENT_SELECTION_REQUEST, ExecuteRequestParamsBase,
+    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_REQUEST, EXECUTE_DOCUMENT_SELECTION_REQUEST, ExecuteRequestParamsBase,
     BATCH_START_NOTIFICATION, BATCH_COMPLETE_NOTIFICATION,
     DEPLOY_BATCH_COMPLETE_NOTIFICATION, DEPLOY_BATCH_START_NOTIFICATION, EXECUTE_DOCUMENT_STATEMENT_REQUEST,
     ExecuteDocumentStatementParams, ExecutionPlanOptions, ResultSetNotificationParams,
@@ -75,7 +75,7 @@ class QueryExecutionService(object):
 
         self._service_action_mapping: dict = {
             EXECUTE_STRING_REQUEST: self._handle_execute_query_request,
-            EXECUTE_DEPLOY_STRING_REQUEST: self.handle_execute_deploy_string_request,
+            EXECUTE_DEPLOY_REQUEST: self.handle_execute_deploy_request,
             EXECUTE_DOCUMENT_SELECTION_REQUEST: self._handle_execute_query_request,
             EXECUTE_DOCUMENT_STATEMENT_REQUEST: self._handle_execute_query_request,
             SUBSET_REQUEST: self._handle_subset_request,
@@ -190,7 +190,7 @@ class QueryExecutionService(object):
 
         self._start_query_execution_thread(request_context, params, worker_args)
 
-    def handle_execute_deploy_string_request(
+    def handle_execute_deploy_request(
         self, request_context: RequestContext, params: ExecuteRequestParamsBase
     ) -> None:
         """Kick off thread to execute query in response to an incoming execute query request"""

--- a/pgsqltoolsservice/query_execution/query_execution_service.py
+++ b/pgsqltoolsservice/query_execution/query_execution_service.py
@@ -21,11 +21,12 @@ from pgsqltoolsservice.query import (
 from pgsqltoolsservice.query.contracts import BatchSummary, ResultSetSubset, SelectionData, SaveResultsRequestParams, SubsetResult  # noqa
 from pgsqltoolsservice.query import ResultSetStorageType
 from pgsqltoolsservice.query_execution.contracts import (
-    EXECUTE_STRING_REQUEST, EXECUTE_DOCUMENT_SELECTION_REQUEST, ExecuteRequestParamsBase,
-    BATCH_START_NOTIFICATION, BATCH_COMPLETE_NOTIFICATION, EXECUTE_DOCUMENT_STATEMENT_REQUEST,
+    EXECUTE_STRING_REQUEST, EXECUTE_DEPLOY_STRING_REQUEST, EXECUTE_DOCUMENT_SELECTION_REQUEST, ExecuteRequestParamsBase,
+    BATCH_START_NOTIFICATION, BATCH_COMPLETE_NOTIFICATION,
+    DEPLOY_BATCH_COMPLETE_NOTIFICATION, DEPLOY_BATCH_START_NOTIFICATION, EXECUTE_DOCUMENT_STATEMENT_REQUEST,
     ExecuteDocumentStatementParams, ExecutionPlanOptions, ResultSetNotificationParams,
-    MESSAGE_NOTIFICATION, RESULT_SET_AVAILABLE_NOTIFICATION, RESULT_SET_COMPLETE_NOTIFICATION, MessageNotificationParams,
-    QUERY_COMPLETE_NOTIFICATION, QUERY_EXECUTION_PLAN_REQUEST, QueryCancelResult, QueryExecutionPlanRequest,
+    MESSAGE_NOTIFICATION, DEPLOY_MESSAGE_NOTIFICATION, RESULT_SET_AVAILABLE_NOTIFICATION, RESULT_SET_COMPLETE_NOTIFICATION, MessageNotificationParams,
+    QUERY_COMPLETE_NOTIFICATION, DEPLOY_COMPLETE_NOTIFICATION, QUERY_EXECUTION_PLAN_REQUEST, QueryCancelResult, QueryExecutionPlanRequest,
     SUBSET_REQUEST, ExecuteDocumentSelectionParams, CANCEL_REQUEST, QueryCancelParams, ResultMessage, SubsetParams,
     BatchNotificationParams, QueryCompleteNotificationParams, QueryDisposeParams,
     DISPOSE_REQUEST, SIMPLE_EXECUTE_REQUEST, SimpleExecuteRequest, ExecuteStringParams,
@@ -74,6 +75,7 @@ class QueryExecutionService(object):
 
         self._service_action_mapping: dict = {
             EXECUTE_STRING_REQUEST: self._handle_execute_query_request,
+            EXECUTE_DEPLOY_STRING_REQUEST: self.handle_execute_deploy_string_request,
             EXECUTE_DOCUMENT_SELECTION_REQUEST: self._handle_execute_query_request,
             EXECUTE_DOCUMENT_STATEMENT_REQUEST: self._handle_execute_query_request,
             SUBSET_REQUEST: self._handle_subset_request,
@@ -171,6 +173,46 @@ class QueryExecutionService(object):
 
         def on_query_complete(query_complete_params):
             request_context.send_notification(QUERY_COMPLETE_NOTIFICATION, query_complete_params)
+
+        # Get a connection for the query
+        try:
+            conn = self._get_connection(params.owner_uri, ConnectionType.QUERY)
+        except Exception as e:
+            if self._service_provider.logger is not None:
+                self._service_provider.logger.exception(
+                    'Encountered exception while handling query request')  # TODO: Localize
+            request_context.send_unhandled_error_response(e)
+            return
+
+        worker_args = ExecuteRequestWorkerArgs(params.owner_uri, conn, request_context, ResultSetStorageType.FILE_STORAGE, before_query_initialize,
+                                               on_batch_start, on_message_notification, on_resultset_complete,
+                                               on_batch_complete, on_query_complete)
+
+        self._start_query_execution_thread(request_context, params, worker_args)
+
+    def handle_execute_deploy_string_request(
+        self, request_context: RequestContext, params: ExecuteRequestParamsBase
+    ) -> None:
+        """Kick off thread to execute query in response to an incoming execute query request"""
+
+        def before_query_initialize(before_query_initialize_params):
+            # Send a response to indicate that the query was kicked off
+            request_context.send_response(before_query_initialize_params)
+
+        def on_batch_start(batch_event_params):
+            request_context.send_notification(DEPLOY_BATCH_START_NOTIFICATION, batch_event_params)
+
+        def on_message_notification(notice_message_params):
+            request_context.send_notification(DEPLOY_MESSAGE_NOTIFICATION, notice_message_params)
+
+        def on_resultset_complete(result_set_params):
+            pass
+
+        def on_batch_complete(batch_event_params):
+            request_context.send_notification(DEPLOY_BATCH_COMPLETE_NOTIFICATION, batch_event_params)
+
+        def on_query_complete(query_complete_params):
+            request_context.send_notification(DEPLOY_COMPLETE_NOTIFICATION, query_complete_params)
 
         # Get a connection for the query
         try:
@@ -318,7 +360,7 @@ class QueryExecutionService(object):
         try:
             query.execute(worker_args.connection)
         except Exception as e:
-            self._resolve_query_exception(e, query, worker_args.request_context, worker_args.connection)
+            self._resolve_query_exception(e, query, worker_args)
         finally:
             # Send a query complete notification
             batch_summaries = [batch.batch_summary for batch in query.batches]
@@ -376,7 +418,7 @@ class QueryExecutionService(object):
             # Then params must be an instance of ExecuteStringParams, which has the query as an attribute
             return params.query
 
-    def _resolve_query_exception(self, e: Exception, query: Query, request_context: RequestContext, conn: 'psycopg2.connection', is_rollback_error=False):
+    def _resolve_query_exception(self, e: Exception, query: Query, worker_args: ExecuteRequestWorkerArgs, is_rollback_error=False):
         utils.log.log_debug(self._service_provider.logger, f'Query execution failed for following query: {query.query_text}\n {e}')
         if isinstance(e, psycopg2.DatabaseError) or isinstance(e, RuntimeError) or isinstance(e, psycopg2.extensions.QueryCanceledError):
             error_message = str(e)
@@ -391,17 +433,17 @@ class QueryExecutionService(object):
 
         # Send a message with the error to the client
         result_message_params = self.build_message_params(query.owner_uri, query.batches[query.current_batch_index].id, error_message, True)
-        request_context.send_notification(MESSAGE_NOTIFICATION, result_message_params)
+        _check_and_fire(worker_args.on_message_notification, result_message_params)
 
         # If there was a failure in the middle of a transaction, roll it back.
         # Note that conn.rollback() won't work since the connection is in autocommit mode
-        if not is_rollback_error and conn.get_transaction_status() is psycopg2.extensions.TRANSACTION_STATUS_INERROR:
+        if not is_rollback_error and worker_args.connection.get_transaction_status() is psycopg2.extensions.TRANSACTION_STATUS_INERROR:
             rollback_query = Query(query.owner_uri, 'ROLLBACK', QueryExecutionSettings(ExecutionPlanOptions(), None), QueryEvents())
             try:
-                rollback_query.execute(conn)
+                rollback_query.execute(worker_args.connection)
             except Exception as rollback_exception:
                 # If the rollback failed, handle the error as usual but don't try to roll back again
-                self._resolve_query_exception(rollback_exception, rollback_query, request_context, conn, True)
+                self._resolve_query_exception(rollback_exception, rollback_query, worker_args, True)
 
     def _save_result(self, params: SaveResultsRequestParams, request_context: RequestContext, file_factory: FileStreamFactory):
         query: Query = self.query_results[params.owner_uri]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from cx_Freeze import setup, Executable
-import os
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
@@ -11,9 +10,6 @@ base = 'Console'
 executables = [
     Executable('pgsqltoolsservice/pgtoolsservice_main.py', base=base)
 ]
-
-os.environ['TCL_LIBRARY'] = r'C:\Users\swjain\AppData\Local\Programs\Python\Python36-32\tcl\tcl8.6'
-os.environ['TK_LIBRARY'] = r'C:\Users\swjain\AppData\Local\Programs\Python\Python36-32\tcl\tk8.6'
 
 setup(name='PostgreSQL Tools Service',
       version='0.1.0',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from cx_Freeze import setup, Executable
+import os
 
 # Dependencies are automatically detected, but it might need
 # fine tuning.
@@ -10,6 +11,9 @@ base = 'Console'
 executables = [
     Executable('pgsqltoolsservice/pgtoolsservice_main.py', base=base)
 ]
+
+os.environ['TCL_LIBRARY'] = r'C:\Users\swjain\AppData\Local\Programs\Python\Python36-32\tcl\tcl8.6'
+os.environ['TK_LIBRARY'] = r'C:\Users\swjain\AppData\Local\Programs\Python\Python36-32\tcl\tk8.6'
 
 setup(name='PostgreSQL Tools Service',
       version='0.1.0',


### PR DESCRIPTION
In Azure Data Studio PostgreSQL extension we are adding a new deploy command where you can deploy your PostgreSQL project. Query notifications can only be subscribed to one handler and is handled by ADS itself so we need a separate query messages and notifications so that we can handle the notifications 