### PR TITLE
Use original unformatted query text for execution

### DIFF
--- a/pgsqltoolsservice/query/query.py
+++ b/pgsqltoolsservice/query/query.py
@@ -71,16 +71,19 @@ class Query:
             formatted_text = sqlparse.format(batch_text, strip_comments=True).strip()
             if not formatted_text or formatted_text == ';':
                 continue
+
+            sql_statement_text = batch_text
+
             # Create and save the batch
             if bool(self._execution_plan_options):
                 if self._execution_plan_options.include_estimated_execution_plan_xml:
-                    formatted_text = Query.EXPLAIN_QUERY_TEMPLATE.format(formatted_text)
+                    sql_statement_text = Query.EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
                 elif self._execution_plan_options.include_actual_execution_plan_xml:
                     self._disable_auto_commit = True
-                    formatted_text = Query.ANALYZE_EXPLAIN_QUERY_TEMPLATE.format(formatted_text)
+                    sql_statement_text = Query.ANALYZE_EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
 
             batch = create_batch(
-                formatted_text,
+                sql_statement_text,
                 len(self.batches),
                 selection_data[index],
                 query_events.batch_events,

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -158,16 +158,13 @@ select * from t1;'''
         for index, batch in enumerate(query.batches):
             self.assertEqual(_tuple_from_selection_data(batch.selection), _tuple_from_selection_data(expected_selections[index]))
 
-
     def test_hash_character_processed_correctly(self):
-        """Test that xor operator is not taken for an inline comment delimiter"""        
-        
+        """Test that xor operator is not taken for an inline comment delimiter"""
         full_query = "select 42 # 24;"
         query = Query('test_uri', full_query, QueryExecutionSettings(ExecutionPlanOptions(), None), QueryEvents())
 
         self.assertEqual(len(query.batches), 1)
         self.assertEqual(full_query, query.batches[0].batch_text)
-
 
     def execute_get_subset_raises_error_when_index_not_in_range(self, batch_index: int):
         full_query = 'Select * from t1;'

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -154,8 +154,20 @@ select * from t1;'''
         expected_selections = [
             SelectionData(start_line=0, start_column=0, end_line=0, end_column=17),
             SelectionData(start_line=3, start_column=1, end_line=3, end_column=18)]
+
         for index, batch in enumerate(query.batches):
             self.assertEqual(_tuple_from_selection_data(batch.selection), _tuple_from_selection_data(expected_selections[index]))
+
+
+    def test_hash_character_processed_correctly(self):
+        """Test that xor operator is not taken for an inline comment delimiter"""        
+        
+        full_query = "select 42 # 24;"
+        query = Query('test_uri', full_query, QueryExecutionSettings(ExecutionPlanOptions(), None), QueryEvents())
+
+        self.assertEqual(len(query.batches), 1)
+        self.assertEqual(full_query, query.batches[0].batch_text)
+
 
     def execute_get_subset_raises_error_when_index_not_in_range(self, batch_index: int):
         full_query = 'Select * from t1;'


### PR DESCRIPTION
This is a fix for microsoft/azuredatastudio-postgresql#160 which is caused by using ```sqlparse``` package which treats the '#' character as a comment delimiter. This is correct behavior in My SQL while PostgreSQL uses it for XOR operator. As a result, the queries like
```
select 
42 # 24 AS "Xor",
~1 AS "Negation";
```
cause syntax error because they get converted to
```
select 42 ~ 1 AS "Negation";
```
or even worse, the ```select 42 # 24;``` is executed as ```select 42``` and it succeeds but it returns incorrect result (42 instead of 50).

With the proposed changes, we will only use the formatted SQL for detecting empty statements and pass the original unformatted SQL for execution.

This is not the best fix available because the same ```sqlparse``` package is still used for splitting the SQL batch into individual statements. However there are fewer situations where it will misbehave, and I would consider it a separate issue.

I also created the following issue in the sqlparse repo: andialbrecht/sqlparse#539