### PR TITLE
Do not convert JSON returned by the server

### DIFF
--- a/pgsqltoolsservice/converters/bytes_to_any_converters.py
+++ b/pgsqltoolsservice/converters/bytes_to_any_converters.py
@@ -6,7 +6,6 @@
 
 from typing import Callable, Any  # noqa
 import struct
-import json
 
 from pgsqltoolsservice.parsers import datatypes
 
@@ -77,12 +76,6 @@ def convert_bytes_to_memoryview(value) -> str:
     return str(value)
 
 
-def convert_bytes_to_dict(value) -> dict:
-    """ Decode bytes to str, and convert it to a valid JSON format """
-    value_str = value.decode(DECODING_METHOD)
-    return json.loads(value_str)
-
-
 def convert_bytes_to_numericrange_format_str(value) -> str:
     """ Since we are not using the NumericRange object, so just convert bytes to str for UI consuming """
     return convert_bytes_to_str(value)
@@ -118,8 +111,8 @@ DATATYPE_READER_MAP = {
     datatypes.DATATYPE_TIMESTAMP_WITH_TIMEZONE: convert_bytes_to_datetime,
     datatypes.DATATYPE_INTERVAL: convert_bytes_to_timedelta,
     datatypes.DATATYPE_UUID: convert_bytes_to_uuid,
-    datatypes.DATATYPE_JSON: convert_bytes_to_dict,
-    datatypes.DATATYPE_JSONB: convert_bytes_to_dict,
+    datatypes.DATATYPE_JSON: convert_bytes_to_str,
+    datatypes.DATATYPE_JSONB: convert_bytes_to_str,
     datatypes.DATATYPE_INT4RANGE: convert_bytes_to_numericrange_format_str,
     datatypes.DATATYPE_INT8RANGE: convert_bytes_to_numericrange_format_str,
     datatypes.DATATYPE_NUMRANGE: convert_bytes_to_numericrange_format_str,

--- a/tests/query/data_storage/test_service_buffer_file_stream_reader.py
+++ b/tests/query/data_storage/test_service_buffer_file_stream_reader.py
@@ -218,24 +218,21 @@ class TestServiceBufferFileStreamReader(unittest.TestCase):
         actual = str(res[0].raw_object)
         self.assertEqual(str(expected), actual)
 
-    def test_read_dict(self):
+    def test_read_json(self):
+        """Test json/jsonb string is returned as is"""
         test_file_offset = 0
         test_row_id = 1
-        test_columns_info = []
 
-        col = DbColumn()
-        col.data_type = datatypes.DATATYPE_JSON
-        test_columns_info.append(col)
+        for datatype in [datatypes.DATATYPE_JSON, datatypes.DATATYPE_JSONB]:
+            col = DbColumn()
+            col.data_type = datatype
+            test_columns_info = [col]
+            reader = ServiceBufferFileStreamReader(self._dict_file_stream)
 
-        res = self._dict_reader.read_row(test_file_offset, test_row_id, test_columns_info)
-        actual_raw_object = res[0].raw_object
-        expected1 = self._dict_test_value["Ser,ver"]
-        actual1 = actual_raw_object["Ser,ver"]
-        expected2 = self._dict_test_value["Sche'ma"]
-        actual2 = actual_raw_object["Sche'ma"]
+            res = reader.read_row(test_file_offset, test_row_id, test_columns_info)
 
-        self.assertEqual(expected1, actual1)
-        self.assertEqual(expected2, actual2)
+            self.assertEqual(1, len(res))
+            self.assertEqual(json.dumps(self._dict_test_value), res[0].raw_object)
 
     def test_read_numericrange(self):
         test_file_offset = 0


### PR DESCRIPTION
This is a fix for: 
https://github.com/microsoft/azuredatastudio-postgresql/issues/130
https://github.com/microsoft/azuredatastudio-postgresql/issues/192

When json data is returned by PostgreSQL, the service runs it through a converter that produces the output that looks like json but it is invalid because it uses Python syntax (e.g. single quotes, capitalized boolean values, etc.)

There is no point to convert the server output because it is already json, and it is already treated as json by the service when it loads it into the python dictionary.
