### PR TITLE
Fix query editor connect/disconnect

### DIFF
--- a/pgsqltoolsservice/query/batch.py
+++ b/pgsqltoolsservice/query/batch.py
@@ -117,7 +117,7 @@ class Batch:
 
         if self._batch_events and self._batch_events._on_execution_started:
             self._batch_events._on_execution_started(self)
-        
+
         cursor = self.get_cursor(connection)
         try:
             cursor.execute(self.batch_text)

--- a/pgsqltoolsservice/query/batch.py
+++ b/pgsqltoolsservice/query/batch.py
@@ -117,11 +117,10 @@ class Batch:
 
         if self._batch_events and self._batch_events._on_execution_started:
             self._batch_events._on_execution_started(self)
-
+        
+        cursor = self.get_cursor(connection)
         try:
-            cursor = self.get_cursor(connection)
             cursor.execute(self.batch_text)
-
             self.after_execute(cursor)
         except psycopg2.DatabaseError as error:
             self._has_error = True

--- a/pgsqltoolsservice/query/query.py
+++ b/pgsqltoolsservice/query/query.py
@@ -141,6 +141,7 @@ class Query:
 
                 batch.execute(connection)
         finally:
+            # 0 if the connection is open, nonzero if it is closed or broken.
             if (connection.closed == 0):
                 connection.autocommit = current_auto_commit_status
             self._execution_state = ExecutionState.EXECUTED

--- a/pgsqltoolsservice/query/query.py
+++ b/pgsqltoolsservice/query/query.py
@@ -141,7 +141,8 @@ class Query:
 
                 batch.execute(connection)
         finally:
-            connection.autocommit = current_auto_commit_status
+            if (connection.closed == 0):
+                connection.autocommit = current_auto_commit_status
             self._execution_state = ExecutionState.EXECUTED
 
     def get_subset(self, batch_index: int, start_index: int, end_index: int):

--- a/pgsqltoolsservice/query/query.py
+++ b/pgsqltoolsservice/query/query.py
@@ -142,6 +142,7 @@ class Query:
                 batch.execute(connection)
         finally:
             # 0 if the connection is open, nonzero if it is closed or broken.
+            # We can only set autocommit when the connection is open.
             if (connection.closed == 0):
                 connection.autocommit = current_auto_commit_status
             self._execution_state = ExecutionState.EXECUTED


### PR DESCRIPTION
When connection is closed by server, the qurery execution fails but we were trying to set autocommit to true on a closed connection which throws an error.
Now check the status of the connection. This will ensure that the status is set to executed and user can connect/disconnect properly.