### PR TITLE
Adding AAD authorization for MySQL databases -- Updated

### DIFF
--- a/ossdbtoolsservice/capabilities/connection_options/mysql_connection_options.py
+++ b/ossdbtoolsservice/capabilities/connection_options/mysql_connection_options.py
@@ -53,6 +53,16 @@ mysql_conn_provider_opts = ConnectionProviderOptions([
         group_name='Security'
     ),
     ConnectionOption(
+        name='azureAccountToken',
+        display_name='Access Token',
+        description='Indicates an Active Directory access token to be used when connecting to the data source',
+        value_type=ConnectionOption.VALUE_TYPE_ACCESS_TOKEN,
+        special_value_type=ConnectionOption.SPECIAL_VALUE_ACCESS_TOKEN_NAME,
+        is_identity=True,
+        is_required=False,
+        group_name='Security'
+    ),
+    ConnectionOption(
         name='bindAddress',
         display_name='Host IP address',
         description='IP address of the server',

--- a/ossdbtoolsservice/driver/types/pymysql_driver.py
+++ b/ossdbtoolsservice/driver/types/pymysql_driver.py
@@ -51,6 +51,10 @@ class MySQLConnection(ServerConnection):
         :param conn_params: connection parameters dict
         :param config: optional Configuration object with mysql connection config
         """
+        
+        if 'azureAccountToken' in conn_params:
+            conn_params['password'] = conn_params['azureAccountToken']            
+
         # Map the provided connection parameter names to pymysql param names
         _params = {MYSQL_CONNECTION_OPTION_KEY_MAP.get(param, param) : value for param, value in conn_params.items()}
 


### PR DESCRIPTION
Adding AAD authorization for MySQL databases (without the previously added package.json file). Fixed:
- Adding azureaccounttoken as a connection property
- Setting the token as the password if a token is provided. This way if AAD auth is used, AAD token replaces standard password when authenticating