### PR TITLE
Add new MySQL connection service tests

### DIFF
--- a/tests/connection/test_mysql_connection_service.py
+++ b/tests/connection/test_mysql_connection_service.py
@@ -19,7 +19,6 @@ from ossdbtoolsservice.connection.contracts import (
     ChangeDatabaseRequestParams, ConnectionCompleteParams, ConnectionDetails,
     ConnectionType, ConnectRequestParams, DisconnectRequestParams,
     ListDatabasesParams)
-from ossdbtoolsservice.driver.types.psycopg_driver import PostgreSQLConnection
 from ossdbtoolsservice.utils.constants import MYSQL_PROVIDER_NAME, DEFAULT_PORT, WORKSPACE_SERVICE_NAME
 from ossdbtoolsservice.utils.cancellation import CancellationToken
 from ossdbtoolsservice.workspace import WorkspaceService
@@ -28,8 +27,8 @@ from tests.mysqlsmo_tests.utils import MockCursor
 from tests.utils import MockPyMySQLConnection, MockRequestContext
 
 
-class TestConnectionService(unittest.TestCase):
-    """Methods for testing the connection service"""
+class TestMySQLConnectionService(unittest.TestCase):
+    """Methods for testing the connection service with a MySQL Connection"""
 
     def setUp(self):
         """Set up the tests with a connection service"""
@@ -72,7 +71,7 @@ class TestConnectionService(unittest.TestCase):
         self.assertFalse(response.server_info.is_cloud)
     
     def test_connect_with_access_token(self):
-        """Test that the service connects to a PostgreSQL server using an access token as a password"""
+        """Test that the service connects to a MySQL server using an access token as a password"""
         # Set up the parameters for the connection
         params: ConnectRequestParams = ConnectRequestParams.from_dict({
             'ownerUri': 'someUri',

--- a/tests/connection/test_mysql_connection_service.py
+++ b/tests/connection/test_mysql_connection_service.py
@@ -1,0 +1,107 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""Test connection.ConnectionService with a MySQL connection"""
+
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock, Mock
+
+import pymysql
+
+import ossdbtoolsservice.connection.connection_service
+import tests.utils as utils
+from ossdbtoolsservice.connection import ConnectionInfo, ConnectionService
+from ossdbtoolsservice.connection.contracts import (
+    CONNECTION_COMPLETE_METHOD, CancelConnectParams,
+    ChangeDatabaseRequestParams, ConnectionCompleteParams, ConnectionDetails,
+    ConnectionType, ConnectRequestParams, DisconnectRequestParams,
+    ListDatabasesParams)
+from ossdbtoolsservice.driver.types.psycopg_driver import PostgreSQLConnection
+from ossdbtoolsservice.utils.constants import MYSQL_PROVIDER_NAME, DEFAULT_PORT, WORKSPACE_SERVICE_NAME
+from ossdbtoolsservice.utils.cancellation import CancellationToken
+from ossdbtoolsservice.workspace import WorkspaceService
+from tests.integration import get_connection_details, integration_test
+from tests.mysqlsmo_tests.utils import MockCursor
+from tests.utils import MockPyMySQLConnection, MockRequestContext
+
+
+class TestConnectionService(unittest.TestCase):
+    """Methods for testing the connection service"""
+
+    def setUp(self):
+        """Set up the tests with a connection service"""
+        self.connection_service = ConnectionService()
+        self.connection_service._service_provider = utils.get_mock_service_provider({WORKSPACE_SERVICE_NAME: WorkspaceService()},
+                                                            provider_name=MYSQL_PROVIDER_NAME)
+        mock_cursor = MockCursor(results=[['5.7.29-log']])
+        # Set up the mock connection for pymysql's connect method to return
+        self.mock_pymysql_connection = MockPyMySQLConnection(parameters={
+            'host': 'myserver',
+            'dbname': 'postgres',
+            'user': 'postgres'}, cursor=mock_cursor)
+
+    def test_connect(self):
+        """Test that the service connects to a MySQL server"""
+        # Set up the parameters for the connection
+        params: ConnectRequestParams = ConnectRequestParams.from_dict({
+            'ownerUri': 'someUri',
+            'type': ConnectionType.DEFAULT,
+            'connection': {
+                'options': {
+                    'user': 'mysql',
+                    'password': 'password',
+                    'host': 'myserver',
+                    'dbname': 'mysql'
+                }
+            }
+        })
+
+        # Set up the connection service and call its connect method with the supported options
+        with mock.patch('pymysql.connect', new=mock.Mock(return_value=self.mock_pymysql_connection)):
+            response = self.connection_service.connect(params)
+
+        # Verify that pymysql's connection method was called and that the
+        # response has a connection id, indicating success.
+        self.assertIs(self.connection_service.owner_to_connection_map[params.owner_uri].get_connection(params.type)._conn,
+                      self.mock_pymysql_connection)
+        self.assertIsNotNone(response.connection_id)
+        self.assertIsNotNone(response.server_info.server_version)
+        self.assertFalse(response.server_info.is_cloud)
+    
+    def test_connect_with_access_token(self):
+        """Test that the service connects to a PostgreSQL server using an access token as a password"""
+        # Set up the parameters for the connection
+        params: ConnectRequestParams = ConnectRequestParams.from_dict({
+            'ownerUri': 'someUri',
+            'type': ConnectionType.DEFAULT,
+            'connection': {
+                'options': {
+                    'user': 'mysql',
+                    'azureAccountToken': 'exampleToken',
+                    'host': 'myserver',
+                    'dbname': 'mysql'
+                }
+            }
+        })
+
+        # Set up pymysql instance for connection service to call
+        mock_connect_method = mock.Mock(return_value=self.mock_pymysql_connection)
+
+        # Set up the connection service and call its connect method with the supported options
+        with mock.patch('pymysql.connect', new=mock_connect_method):
+            response = self.connection_service.connect(params)
+
+        # Verify that pymysql's connection method was called with password set to account token.
+        mock_connect_method.assert_called_once_with(user='mysql', password='exampleToken', host='myserver', 
+                                                    port=DEFAULT_PORT[MYSQL_PROVIDER_NAME], database='mysql')
+
+        # Verify that pymysql's connection method was called and that the
+        # response has a connection id, indicating success.
+        self.assertIs(self.connection_service.owner_to_connection_map[params.owner_uri].get_connection(params.type)._conn,
+                      self.mock_pymysql_connection)
+        self.assertIsNotNone(response.connection_id)
+        self.assertIsNotNone(response.server_info.server_version)
+        self.assertFalse(response.server_info.is_cloud)

--- a/tests/connection/test_pg_connection_service.py
+++ b/tests/connection/test_pg_connection_service.py
@@ -28,8 +28,8 @@ from tests.pgsmo_tests.utils import MockPGServerConnection
 from tests.utils import MockCursor, MockPsycopgConnection, MockRequestContext
 
 
-class TestConnectionService(unittest.TestCase):
-    """Methods for testing the connection service"""
+class TestPGConnectionService(unittest.TestCase):
+    """Methods for testing the connection service with a PG connection"""
 
     def setUp(self):
         """Set up the tests with a connection service"""

--- a/tests/connection/test_pg_connection_service.py
+++ b/tests/connection/test_pg_connection_service.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-"""Test connection.ConnectionService"""
+"""Test connection.ConnectionService with a PG connection"""
 
 import unittest
 from unittest import mock
@@ -20,7 +20,7 @@ from ossdbtoolsservice.connection.contracts import (
     ConnectionType, ConnectRequestParams, DisconnectRequestParams,
     ListDatabasesParams)
 from ossdbtoolsservice.driver.types.psycopg_driver import PostgreSQLConnection
-from ossdbtoolsservice.utils import constants
+from ossdbtoolsservice.utils.constants import DEFAULT_PORT, WORKSPACE_SERVICE_NAME, PG_PROVIDER_NAME
 from ossdbtoolsservice.utils.cancellation import CancellationToken
 from ossdbtoolsservice.workspace import WorkspaceService
 from tests.integration import get_connection_details, integration_test
@@ -34,7 +34,7 @@ class TestConnectionService(unittest.TestCase):
     def setUp(self):
         """Set up the tests with a connection service"""
         self.connection_service = ConnectionService()
-        self.connection_service._service_provider = utils.get_mock_service_provider({constants.WORKSPACE_SERVICE_NAME: WorkspaceService()})
+        self.connection_service._service_provider = utils.get_mock_service_provider({WORKSPACE_SERVICE_NAME: WorkspaceService()})
 
     def test_connect(self):
         """Test that the service connects to a PostgreSQL server"""
@@ -564,7 +564,7 @@ class TestConnectionService(unittest.TestCase):
         """Test that if no database is given, the default database is used"""
         # Set up the connection params and default database name
         default_db = 'test_db'
-        self.connection_service._service_provider[constants.WORKSPACE_SERVICE_NAME].configuration.pgsql.default_database = default_db
+        self.connection_service._service_provider[WORKSPACE_SERVICE_NAME].configuration.pgsql.default_database = default_db
         params: ConnectRequestParams = ConnectRequestParams.from_dict({
             'ownerUri': 'someUri',
             'type': ConnectionType.DEFAULT,
@@ -593,7 +593,7 @@ class TestConnectionService(unittest.TestCase):
         # Set up the connection params and default database name
         default_db = 'test_db'
         actual_db = 'postgres'
-        self.connection_service._service_provider[constants.WORKSPACE_SERVICE_NAME].configuration.pgsql.default_database = default_db
+        self.connection_service._service_provider[WORKSPACE_SERVICE_NAME].configuration.pgsql.default_database = default_db
         params: ConnectRequestParams = ConnectRequestParams.from_dict({
             'ownerUri': 'someUri',
             'type': ConnectionType.DEFAULT,
@@ -649,7 +649,7 @@ class TestConnectionCancellation(unittest.TestCase):
         """Set up the tests with common connection parameters"""
         # Set up the mock connection service and connection info
         self.connection_service = ConnectionService()
-        self.connection_service._service_provider = utils.get_mock_service_provider({constants.WORKSPACE_SERVICE_NAME: WorkspaceService()})
+        self.connection_service._service_provider = utils.get_mock_service_provider({WORKSPACE_SERVICE_NAME: WorkspaceService()})
         self.owner_uri = 'test_uri'
         self.connection_type = ConnectionType.DEFAULT
         self.connect_params: ConnectRequestParams = ConnectRequestParams.from_dict({
@@ -800,7 +800,8 @@ class TestConnectionCancellation(unittest.TestCase):
             response = self.connection_service.connect(params)
 
         # Verify that psycopg2's connection method was called with password set to account token.
-        mock_connect_method.assert_called_once_with(user='postgres', password='exampleToken', host='myserver', port=5432, dbname='postgres')
+        mock_connect_method.assert_called_once_with(user='postgres', password='exampleToken', host='myserver', 
+                                                    port=DEFAULT_PORT[PG_PROVIDER_NAME], dbname='postgres')
 
         # Verify that psycopg2's connection method was called and that the
         # response has a connection id, indicating success.


### PR DESCRIPTION
* Added a new file for MySQL connection service tests and tested connect and connect with azure account token (newly added in #261)