### PR TITLE
Fix MySQL format document request handling

### DIFF
--- a/ossdbtoolsservice/language/language_service.py
+++ b/ossdbtoolsservice/language/language_service.py
@@ -298,7 +298,8 @@ class LanguageService:
             sqlparse_options['indent_width'] = options.tab_size
         try:
             # Look up workspace config in a try block in case it's not defined / set
-            format_options = self._workspace_service.configuration.pgsql.format
+            config = self._workspace_service.configuration
+            format_options = config.get_configuration(self._service_provider._provider_name).format
             if format_options:
                 sqlparse_options = {**sqlparse_options, **format_options.__dict__}
         except AttributeError:

--- a/ossdbtoolsservice/workspace/__init__.py
+++ b/ossdbtoolsservice/workspace/__init__.py
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from ossdbtoolsservice.workspace.contracts import (
-    Configuration, PGSQLConfiguration, SQLConfiguration, IntellisenseConfiguration,
+    Configuration, MySQLConfiguration, PGSQLConfiguration, SQLConfiguration, IntellisenseConfiguration,
     FormatterConfiguration, TextDocumentIdentifier
 )
 from ossdbtoolsservice.workspace.script_file import ScriptFile
@@ -12,6 +12,6 @@ from ossdbtoolsservice.workspace.workspace_service import WorkspaceService
 from ossdbtoolsservice.workspace.workspace import Workspace
 
 __all__ = [
-    'Configuration', 'PGSQLConfiguration', 'SQLConfiguration', 'IntellisenseConfiguration', 'FormatterConfiguration',
-    'ScriptFile', 'WorkspaceService', 'Workspace', 'TextDocumentIdentifier'
+    'Configuration', 'MySQLConfiguration,', 'PGSQLConfiguration', 'SQLConfiguration', 'IntellisenseConfiguration',
+    'FormatterConfiguration', 'ScriptFile', 'WorkspaceService', 'Workspace', 'TextDocumentIdentifier'
 ]

--- a/ossdbtoolsservice/workspace/contracts/__init__.py
+++ b/ossdbtoolsservice/workspace/contracts/__init__.py
@@ -5,7 +5,7 @@
 
 from ossdbtoolsservice.workspace.contracts.did_change_config_notification import (
     DID_CHANGE_CONFIG_NOTIFICATION, DidChangeConfigurationParams,
-    Configuration, PGSQLConfiguration, SQLConfiguration, IntellisenseConfiguration,
+    Configuration, MySQLConfiguration, PGSQLConfiguration, SQLConfiguration, IntellisenseConfiguration,
     FormatterConfiguration
 )
 from ossdbtoolsservice.workspace.contracts.did_change_text_doc_notification import (
@@ -23,8 +23,8 @@ from ossdbtoolsservice.workspace.contracts.common import (
 
 __all__ = [
     'DID_CHANGE_CONFIG_NOTIFICATION', 'DidChangeConfigurationParams',
-    'Configuration', 'PGSQLConfiguration', 'SQLConfiguration', 'IntellisenseConfiguration', 'FormatterConfiguration',
-    'DID_CHANGE_TEXT_DOCUMENT_NOTIFICATION', 'DidChangeTextDocumentParams', 'TextDocumentChangeEvent',
+    'Configuration', 'MySQLConfiguration,''PGSQLConfiguration', 'SQLConfiguration', 'IntellisenseConfiguration',
+    'FormatterConfiguration', 'DID_CHANGE_TEXT_DOCUMENT_NOTIFICATION', 'DidChangeTextDocumentParams', 'TextDocumentChangeEvent',
     'DID_OPEN_TEXT_DOCUMENT_NOTIFICATION', 'DidOpenTextDocumentParams',
     'DID_CLOSE_TEXT_DOCUMENT_NOTIFICATION', 'DidCloseTextDocumentParams',
     'Location', 'Position', 'Range', 'TextDocumentItem', 'TextDocumentIdentifier', 'TextDocumentPosition'

--- a/tests/language/test_language_service.py
+++ b/tests/language/test_language_service.py
@@ -442,7 +442,6 @@ class TestLanguageService(unittest.TestCase):
         self.assert_range_equals(edits[0].range, Range.from_data(0, 0, 0, len(input_text)))
         self.assertEqual(edits[0].new_text, expected_output)
 
-
     def test_format_doc_range(self):
         """
         Test that the format document range codepath works as expected


### PR DESCRIPTION
* Fixed language service to grab provider specific format doc configurations, instead of always taking the PG configs. This fixed MySQL format document request handling. 

* Added MySQL format doc tests and doc range tests
