### PR TITLE
Add pydevd dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ parameterized
 coverage
 autopep8
 flake8==3.7.0
+pydevd==1.9.2
 ptvsd==4.3.2
 python-dateutil


### PR DESCRIPTION
* Add pydevd dependency to requirements.txt because vsix package was throwing module missing errors. 