### PR TITLE
Bump psycopg2 version to 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Shared Requirements
-psycopg2==2.7.5
+psycopg2==2.8
 PyMySQL==0.9.3
 
 # ossdbtoolsservice Requirements


### PR DESCRIPTION
This fixes a crash in Azure Data Studio on Ubuntu 20.04, see [this issue](https://github.com/microsoft/azuredatastudio-postgresql/issues/218).