### PR TITLE
Explicitly include pydev_runfiles to fix module not find error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ xlsxwriter
 jinja2
 
 # Build/Test Requirements
-cx_freeze==5.0.2
+cx_freeze==6.1.0
 nose
 parameterized
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ xlsxwriter
 jinja2
 
 # Build/Test Requirements
-cx_freeze==6.1.0
+cx_freeze==5.0.2
 nose
 parameterized
 coverage

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from cx_Freeze import setup, Executable
 # fine tuning.
 include_files = [('./ossdbtoolsservice/pg_exes', './pg_exes')]
 buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse',
-                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8'],
+                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles'],
                     excludes=[], include_files=include_files)
 
 base = 'Console'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from cx_Freeze import setup, Executable
 # fine tuning.
 include_files = [('./ossdbtoolsservice/pg_exes', './pg_exes')]
 buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse',
-                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles', 'zlib'],
+                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles'],
                     excludes=[], include_files=include_files)
 
 base = 'Console'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from cx_Freeze import setup, Executable
 # Dependencies are automatically detected, but it might need
 # fine tuning.
 include_files = [('./ossdbtoolsservice/pg_exes', './pg_exes')]
-buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse', 'dateutil',
+buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse',
                               'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles'],
                     excludes=[], include_files=include_files)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from cx_Freeze import setup, Executable
 # fine tuning.
 include_files = [('./ossdbtoolsservice/pg_exes', './pg_exes')]
 buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse',
-                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles'],
+                              'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles', 'zlib'],
                     excludes=[], include_files=include_files)
 
 base = 'Console'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from cx_Freeze import setup, Executable
 # Dependencies are automatically detected, but it might need
 # fine tuning.
 include_files = [('./ossdbtoolsservice/pg_exes', './pg_exes')]
-buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse',
+buildOptions = dict(packages=['asyncio', 'jinja2', 'psycopg2', 'pymysql', 'inflection', 'sqlparse', 'dateutil',
                               'prompt_toolkit', 'xlsxwriter', 'nose', 'parameterized', 'coverage', 'autopep8', 'flake8', '_pydev_runfiles'],
                     excludes=[], include_files=include_files)
 


### PR DESCRIPTION
pydev_runfiles module is not being added to the package created by cx_freeze, adding it explicitly to be included