### PR TITLE
Fix empty string shown as null value

### DIFF
--- a/ossdbtoolsservice/query/data_storage/service_buffer_file_stream_reader.py
+++ b/ossdbtoolsservice/query/data_storage/service_buffer_file_stream_reader.py
@@ -59,12 +59,12 @@ class ServiceBufferFileStreamReader(ServiceBufferFileStream):
                 value = DbCellValue(display_value=None, is_null=True, raw_object=None, row_id=row_id)
             else:
                 # read the length of data, then update the offset by plus 4, since the int holds 4 bytes
-                raw_bytes_length_to_read = self._read_bytes_from_file(self._file_stream, current_file_offset, 4)
-                if raw_bytes_length_to_read == b'\x00\x00\x00\x00':
-                    # if byte length to read is 0, then it's a NULL value.
-                    current_file_offset += 4
+                null_value_checker = self._read_bytes_from_file(self._file_stream, current_file_offset, 1)
+                current_file_offset += 1
+                if null_value_checker == b'\x01':
                     value = DbCellValue(display_value=str("NULL"), is_null=True, raw_object=None, row_id=row_id)
                 else:
+                    raw_bytes_length_to_read = self._read_bytes_from_file(self._file_stream, current_file_offset, 4)
                     bytes_length_to_read = struct.unpack('i', raw_bytes_length_to_read)[0]
                     current_file_offset += 4
 

--- a/ossdbtoolsservice/query/data_storage/service_buffer_file_stream_writer.py
+++ b/ossdbtoolsservice/query/data_storage/service_buffer_file_stream_writer.py
@@ -59,15 +59,14 @@ class ServiceBufferFileStreamWriter(ServiceBufferFileStream):
 
             # Write the object into the temp file
             if reader.is_none(index):
-                # if it's a NULL value, the bytes length to write is 0
-                row_bytes += self._write_to_file(self._file_stream, bytearray(struct.pack("i", 0)))
-                row_bytes += self._write_null()
+                row_bytes += self._write_to_file(self._file_stream, bytearray(struct.pack("?", True))) # Null value
             else:
                 bytes_converter: Callable[[str], bytearray] = get_any_to_bytes_converter(type_value, provider=column.provider)
                 value_to_write = bytes_converter(values[index])
 
                 bytes_length_to_write = len(value_to_write)
 
+                row_bytes += self._write_to_file(self._file_stream, bytearray(struct.pack("?", False))) # Not Null
                 row_bytes += self._write_to_file(self._file_stream, bytearray(struct.pack("i", bytes_length_to_write)))
                 row_bytes += self._write_to_file(self._file_stream, value_to_write)
 


### PR DESCRIPTION
Issues:
microsoft/azuredatastudio-postgresql#168
microsoft/azuredatastudio-postgresql#143
microsoft/azuredatastudio-postgresql#236

RCA:
empty string and null value are both written in bytes array '0000 0000'
Added one more logic to differentiate NULL value and non Null value