### PR TITLE
Have ADS treat connections as different through port and host

### DIFF
--- a/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
+++ b/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
@@ -67,6 +67,7 @@ pg_conn_provider_opts = ConnectionProviderOptions([
         display_name='Host IP address',
         description='IP address of the server',
         value_type=ConnectionOption.VALUE_TYPE_STRING,
+        is_identity=True,
         group_name='Server'
     ),
     ConnectionOption(
@@ -74,6 +75,7 @@ pg_conn_provider_opts = ConnectionProviderOptions([
         display_name='Port',
         description='Port number for the server',
         value_type=ConnectionOption.VALUE_TYPE_STRING,
+        is_identity=True,
         group_name='Server'
     ),
     ConnectionOption(


### PR DESCRIPTION
Add 'isIdentity= true' to the port and host option in package.json, this will make ADS be able to treat them as different connections.

Tied with ADS fix: microsoft/azuredatastudio#17229
Tied with pg extension fix: https://github.com/microsoft/azuredatastudio-postgresql/pull/293

This PR fixes microsoft/azuredatastudio-postgresql#113