### PR TITLE
Add suggestions to error

### DIFF
--- a/ossdbtoolsservice/connection/connection_service.py
+++ b/ossdbtoolsservice/connection/connection_service.py
@@ -321,6 +321,7 @@ def _build_connection_response_error(connection_info: ConnectionInfo, connection
     response.owner_uri = connection_info.owner_uri
     response.type = connection_type
 
+    """Add suggestions to error message. Will want to check for error code in the future."""
     errorMessage = str(err)
     if "could not translate host name" in errorMessage:
         errorMessage += """\nCauses:
@@ -330,6 +331,9 @@ def _build_connection_response_error(connection_info: ConnectionInfo, connection
     if "could not connect to server: Connection timed out" in errorMessage:
         errorMessage += """\nSuggestions:
         Check that the firewall settings allow connections from the user's address."""
+    elif "could not connect to server: Operation timed out" in errorMessage:
+        errorMessage += """\nSuggestions:
+        Check that the firewall settings allow connections from the user's address.""" 
 
     response.messages = errorMessage
     response.error_message = errorMessage

--- a/ossdbtoolsservice/connection/connection_service.py
+++ b/ossdbtoolsservice/connection/connection_service.py
@@ -320,8 +320,19 @@ def _build_connection_response_error(connection_info: ConnectionInfo, connection
     response: ConnectionCompleteParams = ConnectionCompleteParams()
     response.owner_uri = connection_info.owner_uri
     response.type = connection_type
-    response.messages = str(err)
-    response.error_message = str(err)
+
+    errorMessage = str(err)
+    if "could not translate host name" in errorMessage:
+        errorMessage += """\nCauses:
+    Using the wrong hostname or problems with DNS resolution.\nSuggestions:
+    Check that the server address or hostname is the full address."""
+
+    if "could not connect to server: Connection timed out" in errorMessage:
+        errorMessage += """\nSuggestions:
+        Check that the firewall settings allow connections from the user's address."""
+
+    response.messages = errorMessage
+    response.error_message = errorMessage
 
     return response
 

--- a/ossdbtoolsservice/connection/connection_service.py
+++ b/ossdbtoolsservice/connection/connection_service.py
@@ -333,7 +333,7 @@ def _build_connection_response_error(connection_info: ConnectionInfo, connection
         Check that the firewall settings allow connections from the user's address."""
     elif "could not connect to server: Operation timed out" in errorMessage:
         errorMessage += """\nSuggestions:
-        Check that the firewall settings allow connections from the user's address.""" 
+        Check that the firewall settings allow connections from the user's address."""
 
     response.messages = errorMessage
     response.error_message = errorMessage


### PR DESCRIPTION
The Connection error dialog shown to users without set firewall rules suggest checking the firewall settings.
![image](https://user-images.githubusercontent.com/69922333/140824909-e12056fa-cc08-4d1c-8fd2-bdfa53f46327.png)

Check that the server address or hostname is the full address to the Connection Error message dialog.
![image](https://user-images.githubusercontent.com/69922333/140824940-cc6221f0-b5f7-4a21-940c-3d1e49c4b03f.png)


This PR fixes #
microsoft/azuredatastudio-postgresql#133
microsoft/azuredatastudio-postgresql#132