### PR TITLE
fixing autocomplete refresh for functions and views

### DIFF
--- a/ossdbtoolsservice/language/completion/mysql_completer.py
+++ b/ossdbtoolsservice/language/completion/mysql_completer.py
@@ -60,7 +60,7 @@ class MySQLCompleter(Completer):
                 self.logger.info(msg, *args)
 
     def escape_name(self, name):
-        if name and ((not self.name_pattern.match(name))
+        if name and ((not self.name_pattern.match(name.lower()))
                      or (name.upper() in self.reserved_words)
                      or (name.upper() in self.functions)):
             name = '`%s`' % name

--- a/ossdbtoolsservice/language/completion_refresher.py
+++ b/ossdbtoolsservice/language/completion_refresher.py
@@ -184,18 +184,18 @@ def refresh_casing(completer: PGCompleter or MySQLCompleter, metadata_executor: 
             completer.extend_casing([line.strip() for line in f])
 
 
-@pg_refresher('functions')
-@mysql_refresher('functions')
-def refresh_functions(completer: PGCompleter or MySQLCompleter, metadata_executor: MetadataExecutor):
-    completer.extend_functions(metadata_executor.functions())
-
-
 @mysql_refresher('schemata')
 def mysql_refresh_schemata(completer, metadata_executor):
     # schemata - In MySQL Schema is the same as database. But for mycli
     # schemata will be the name of the current database.
     completer.extend_schemata(metadata_executor.server._maintenance_db_name)
     completer.set_dbname(metadata_executor.server._maintenance_db_name)
+
+
+@pg_refresher('functions')
+@mysql_refresher('functions')
+def refresh_functions(completer: PGCompleter or MySQLCompleter, metadata_executor: MetadataExecutor):
+    completer.extend_functions(metadata_executor.functions())
 
 
 @mysql_refresher('tables')


### PR DESCRIPTION
Functions refresh was failing because it was happening before schemata refresh in ordered dictionary. As a result, all the subsequent refreshes in the dictionary were failing. Changed the order in dictionary to fix the issue.