### PR TITLE
Dashboard procedure script fix

### DIFF
--- a/ossdbtoolsservice/metadata/metadata_service.py
+++ b/ossdbtoolsservice/metadata/metadata_service.py
@@ -113,7 +113,8 @@ class MetadataService:
                 schema_name = row[0]
                 object_name = row[1]
                 object_type = _METADATA_TYPE_MAP[row[2]]
-                metadata_list.append(ObjectMetadata(None, object_type, None, object_name, schema_name))
+                object_type_name = _METADATA_TYPE_NAME_MAP[row[2]]
+                metadata_list.append(ObjectMetadata(None, object_type, object_type_name, object_name, schema_name))
         return metadata_list
 
 
@@ -122,4 +123,11 @@ _METADATA_TYPE_MAP = {
     't': MetadataType.TABLE,
     'v': MetadataType.VIEW,
     's': MetadataType.SPROC
+}
+
+_METADATA_TYPE_NAME_MAP = {
+    'f': 'Function',
+    't': 'Table',
+    'v': 'View',
+    's': 'Procedure'
 }

--- a/tests/metadata/test_metadata_service.py
+++ b/tests/metadata/test_metadata_service.py
@@ -42,12 +42,12 @@ class TestMetadataService(unittest.TestCase):
         """Test that the metadata list handler properly starts a thread to list metadata and responds with the list"""
         # Set up the parameters and mocks for the request
         expected_metadata = [
-            ObjectMetadata(schema='schema1', name='table1', metadata_type=MetadataType.TABLE),
-            ObjectMetadata(schema='schema1', name='view1', metadata_type=MetadataType.VIEW),
-            ObjectMetadata(schema='schema1', name='function1', metadata_type=MetadataType.FUNCTION),
-            ObjectMetadata(schema='schema1', name='table2', metadata_type=MetadataType.TABLE),
-            ObjectMetadata(schema='schema2', name='view1', metadata_type=MetadataType.VIEW),
-            ObjectMetadata(schema='schema2', name='function1', metadata_type=MetadataType.FUNCTION),
+            ObjectMetadata(schema='schema1', name='table1', metadata_type=MetadataType.TABLE, metadata_type_name='Table'),
+            ObjectMetadata(schema='schema1', name='view1', metadata_type=MetadataType.VIEW, metadata_type_name='View'),
+            ObjectMetadata(schema='schema1', name='function1', metadata_type=MetadataType.FUNCTION, metadata_type_name='Function'),
+            ObjectMetadata(schema='schema1', name='table2', metadata_type=MetadataType.TABLE, metadata_type_name='Table'),
+            ObjectMetadata(schema='schema2', name='view1', metadata_type=MetadataType.VIEW, metadata_type_name='View'),
+            ObjectMetadata(schema='schema2', name='function1', metadata_type=MetadataType.FUNCTION, metadata_type_name='Function'),
         ]
 
         metadata_type_to_str_map = {


### PR DESCRIPTION
Issue Summary:
In Dashboard, create as script not working on stored procedure.

RCA:
Because of object_type_name being empty,[ sql-opsdataprotocol client is setting object_type_name](https://github.com/microsoft/sqlops-dataprotocolclient/blob/205a11059edf0dabfe052897050705ac10da4c94/src/protocolConverter.ts#L27) to StoredProcedure.
And Mysql toolsservice expects object_type_name as 'Procedure' in script-as-create request for Stored Procedures.

Fix:
Stated passing object_type_name in object metadata
