### PR TITLE
Remove illegal argument when backing up PG database 

### DIFF
--- a/ossdbtoolsservice/disaster_recovery/disaster_recovery_service.py
+++ b/ossdbtoolsservice/disaster_recovery/disaster_recovery_service.py
@@ -119,8 +119,7 @@ def _perform_backup(connection_info: ConnectionInfo, params: BackupParams, task:
         return TaskResult(TaskStatus.FAILED, str(e))
     pg_dump_args = [pg_dump_location,
                     f'--file={params.backup_info.path}',
-                    f'--format={_BACKUP_FORMAT_MAP[params.backup_info.type]}',
-                    "--disable-dynamic-loading"]
+                    f'--format={_BACKUP_FORMAT_MAP[params.backup_info.type]}']
     pg_dump_args += _get_backup_restore_connection_params(connection_info.details.options)
     # Remove the options that were already used, and pass the rest so that they can be automatically serialized
     options = params.backup_info.__dict__.copy()


### PR DESCRIPTION
Fixing error from pg_dump: illegal option -- disable-dynamic-loading