### PR TITLE
Fix display of partitioned tables

### DIFF
--- a/pgsmo/objects/table/templates/+default/acl.sql
+++ b/pgsmo/objects/table/templates/+default/acl.sql
@@ -30,7 +30,7 @@ from (
             LEFT OUTER JOIN pg_tablespace spc on spc.oid=rel.reltablespace
             LEFT OUTER JOIN pg_constraint con ON con.conrelid=rel.oid AND con.contype='p'
             LEFT OUTER JOIN pg_class tst ON tst.oid = rel.reltoastrelid
-          WHERE rel.relkind IN ('r','s','t') AND rel.relnamespace = {{ scid }}::oid
+          WHERE rel.relkind IN ('r','s','t','p') AND rel.relnamespace = {{ scid }}::oid
                 AND rel.oid = {{ tid }}::OID
       ) rel
     LEFT JOIN information_schema.table_privileges acls ON (table_name = rel.relname)

--- a/pgsmo/objects/table/templates/+default/get_oid.sql
+++ b/pgsmo/objects/table/templates/+default/get_oid.sql
@@ -6,6 +6,6 @@
  #}
 SELECT rel.oid as tid
 FROM pg_class rel
-WHERE rel.relkind IN ('r','s','t')
+WHERE rel.relkind IN ('r','s','t','p')
 AND rel.relnamespace = {{ scid }}::oid
 AND rel.relname = {{data.name|qtLiteral}}

--- a/pgsmo/objects/table/templates/+default/get_relations.sql
+++ b/pgsmo/objects/table/templates/+default/get_relations.sql
@@ -8,7 +8,7 @@
 SELECT c.oid, quote_ident(n.nspname)||'.'||quote_ident(c.relname) AS like_relation
 FROM pg_class c, pg_namespace n
 WHERE c.relnamespace=n.oid
-    AND c.relkind IN ('r', 'v', 'f')
+    AND c.relkind IN ('r', 'v', 'f', 'p')
 {% if not show_sys_objects %}
 {{ CATALOG.VALID_CATALOGS(server_type) }}
 {% endif %}

--- a/pgsmo/objects/table/templates/+default/get_table.sql
+++ b/pgsmo/objects/table/templates/+default/get_table.sql
@@ -9,6 +9,6 @@ SELECT
 FROM
     pg_class rel
 WHERE
-    rel.relkind IN ('r','s','t')
+    rel.relkind IN ('r','s','t','p')
     AND rel.relnamespace = {{ scid }}::oid
     AND rel.oid = {{ tid }}::oid;

--- a/pgsmo/objects/table/templates/+default/nodes.sql
+++ b/pgsmo/objects/table/templates/+default/nodes.sql
@@ -8,6 +8,7 @@
 SELECT  rel.oid,
         (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid) AS triggercount,
         (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid AND tgenabled = 'O') AS has_enable_triggers,
+        (CASE WHEN rel.relkind = 'p' THEN true ELSE false END) AS is_partitioned,
         nsp.nspname AS schema,
         nsp.oid AS schemaoid,
         rel.relname AS name,
@@ -16,4 +17,5 @@ FROM pg_class rel
 INNER JOIN pg_namespace nsp ON rel.relnamespace= nsp.oid
     WHERE rel.relkind IN ('r','t','f','p')
      {% if tid %} AND rel.oid = {{tid}}::OID {% endif %}
+    AND NOT rel.relispartition
     ORDER BY nsp.nspname, rel.relname;

--- a/pgsmo/objects/table/templates/+default/nodes.sql
+++ b/pgsmo/objects/table/templates/+default/nodes.sql
@@ -14,6 +14,6 @@ SELECT  rel.oid,
         {{ SYSOBJECTS.IS_SYSTEMSCHEMA('nsp') }} as is_system
 FROM pg_class rel
 INNER JOIN pg_namespace nsp ON rel.relnamespace= nsp.oid
-    WHERE rel.relkind IN ('r','t','f') 
+    WHERE rel.relkind IN ('r','t','f','p')
      {% if tid %} AND rel.oid = {{tid}}::OID {% endif %}
     ORDER BY nsp.nspname, rel.relname;

--- a/pgsmo/objects/table/templates/+default/properties.sql
+++ b/pgsmo/objects/table/templates/+default/properties.sql
@@ -74,7 +74,7 @@ FROM (
 		LEFT OUTER JOIN pg_constraint con ON con.conrelid=rel.oid AND con.contype='p'
 		LEFT OUTER JOIN pg_class tst ON tst.oid = rel.reltoastrelid
 
-	 WHERE rel.relkind IN ('r','s','t') AND rel.relnamespace = {{ scid }}
+	 WHERE rel.relkind IN ('r','s','t','p') AND rel.relnamespace = {{ scid }}
 	{% if oid %}  AND rel.oid = {{ oid }}::oid {% endif %}
 ) AS TableInformation
  ORDER BY name

--- a/pgsmo/objects/table/templates/9.1_plus/acl.sql
+++ b/pgsmo/objects/table/templates/9.1_plus/acl.sql
@@ -32,7 +32,7 @@ FROM
           LEFT OUTER JOIN pg_constraint con ON con.conrelid=rel.oid AND con.contype='p'
           LEFT OUTER JOIN pg_class tst ON tst.oid = rel.reltoastrelid
           LEFT JOIN pg_type typ ON rel.reloftype=typ.oid
-        WHERE rel.relkind IN ('r','s','t') AND rel.relnamespace = {{ scid }}::oid
+        WHERE rel.relkind IN ('r','s','t','p') AND rel.relnamespace = {{ scid }}::oid
             AND rel.oid = {{ tid }}::oid
     ) acl,
     (SELECT (d).grantee AS grantee, (d).grantor AS grantor, (d).is_grantable
@@ -43,7 +43,7 @@ FROM
           LEFT OUTER JOIN pg_constraint con ON con.conrelid=rel.oid AND con.contype='p'
           LEFT OUTER JOIN pg_class tst ON tst.oid = rel.reltoastrelid
           LEFT JOIN pg_type typ ON rel.reloftype=typ.oid
-        WHERE rel.relkind IN ('r','s','t') AND rel.relnamespace = {{ scid }}::oid
+        WHERE rel.relkind IN ('r','s','t','p') AND rel.relnamespace = {{ scid }}::oid
             AND rel.oid = {{ tid }}::oid
         ) a) d
     ) d

--- a/pgsmo/objects/table/templates/9.1_plus/nodes.sql
+++ b/pgsmo/objects/table/templates/9.1_plus/nodes.sql
@@ -8,6 +8,7 @@
 SELECT  rel.oid,
         (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE) AS triggercount,
         (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE AND tgenabled = 'O') AS has_enable_triggers,
+        (CASE WHEN rel.relkind = 'p' THEN true ELSE false END) AS is_partitioned,
         nsp.nspname AS schema,
         nsp.oid AS schemaoid,
         rel.relname AS name,
@@ -16,4 +17,5 @@ FROM    pg_class rel
 INNER JOIN pg_namespace nsp ON rel.relnamespace= nsp.oid
     WHERE rel.relkind IN ('r','t','f','p')
     {% if tid %} AND rel.oid = {{tid}}::OID {% endif %}
+    AND NOT rel.relispartition
     ORDER BY nsp.nspname, rel.relname;

--- a/pgsmo/objects/table/templates/9.1_plus/nodes.sql
+++ b/pgsmo/objects/table/templates/9.1_plus/nodes.sql
@@ -14,6 +14,6 @@ SELECT  rel.oid,
         {{ SYSOBJECTS.IS_SYSTEMSCHEMA('nsp') }} as is_system
 FROM    pg_class rel
 INNER JOIN pg_namespace nsp ON rel.relnamespace= nsp.oid
-    WHERE rel.relkind IN ('r','t','f')
+    WHERE rel.relkind IN ('r','t','f','p')
     {% if tid %} AND rel.oid = {{tid}}::OID {% endif %}
     ORDER BY nsp.nspname, rel.relname;

--- a/pgsmo/objects/table/templates/9.1_plus/properties.sql
+++ b/pgsmo/objects/table/templates/9.1_plus/properties.sql
@@ -70,6 +70,6 @@ FROM pg_class rel
   LEFT OUTER JOIN pg_constraint con ON con.conrelid=rel.oid AND con.contype='p'
   LEFT OUTER JOIN pg_class tst ON tst.oid = rel.reltoastrelid
   LEFT JOIN pg_type typ ON rel.reloftype=typ.oid
-WHERE rel.relkind IN ('r','s','t') AND rel.relnamespace = {{ scid }}::oid
+WHERE rel.relkind IN ('r','s','t','p') AND rel.relnamespace = {{ scid }}::oid
 {% if oid %}  AND rel.oid = {{ oid }}::oid {% endif %}
 ORDER BY rel.relname;

--- a/pgsmo/objects/table_objects/column/+default/nodes.sql
+++ b/pgsmo/objects/table_objects/column/+default/nodes.sql
@@ -29,6 +29,6 @@ WHERE
         AND attr.attnum > 0
     {% endif %}
     AND atttypid <> 0 AND
-    relkind IN ('r', 'v', 'm') AND
+    relkind IN ('r', 'v', 'm', 'p') AND
     NOT attisdropped 
 ORDER BY attnum

--- a/pgsmo/objects/table_objects/column/9.2_plus/nodes.sql
+++ b/pgsmo/objects/table_objects/column/9.2_plus/nodes.sql
@@ -37,6 +37,6 @@ WHERE
  AND attr.attnum > 0
  {% endif %}
  AND atttypid <> 0 AND
- relkind IN ('r', 'v', 'm') AND
+ relkind IN ('r', 'v', 'm', 'p') AND
  NOT attisdropped 
 ORDER BY attnum


### PR DESCRIPTION
Fixes https://github.com/microsoft/azuredatastudio-postgresql/issues/126
Fixes https://github.com/microsoft/azuredatastudio-postgresql/issues/156

### Before

![before](https://github.com/microsoft/pgtoolsservice/assets/48225118/ac6508d4-8bc3-40ab-adae-7d00474f2220)

### After

![after](https://github.com/microsoft/pgtoolsservice/assets/48225118/0f26bdee-4b29-450c-8c27-987ecb2893aa)

### Status

Opening this as a draft PR to investigate adding tests for this behavior, as well as adding a "Partitions" node inside the tree item for the table.