### PR TITLE
Addressing Save As issues from queries

### DIFF
--- a/ossdbtoolsservice/query/data_storage/save_as_csv_writer.py
+++ b/ossdbtoolsservice/query/data_storage/save_as_csv_writer.py
@@ -19,7 +19,7 @@ class SaveAsCsvWriter(SaveAsWriter):
 
     def write_row(self, row: List[DbCellValue], columns: List[DbColumn]):
 
-        writer = csv.writer(self._file_stream, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        writer = csv.writer(self._file_stream, delimiter=self._params.delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
 
         if self._params.include_headers and not self._header_written:
             selected_column_names = [column.column_name for column in columns[

--- a/ossdbtoolsservice/query/data_storage/save_as_csv_writer.py
+++ b/ossdbtoolsservice/query/data_storage/save_as_csv_writer.py
@@ -19,7 +19,7 @@ class SaveAsCsvWriter(SaveAsWriter):
 
     def write_row(self, row: List[DbCellValue], columns: List[DbColumn]):
 
-        writer = csv.writer(self._file_stream, delimiter=self._params.delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL)
+        writer = csv.writer(self._file_stream, delimiter=self._params.delimiter, quotechar='"', quoting=csv.QUOTE_MINIMAL, lineterminator='\n')
 
         if self._params.include_headers and not self._header_written:
             selected_column_names = [column.column_name for column in columns[

--- a/ossdbtoolsservice/query/data_storage/save_as_excel_writer.py
+++ b/ossdbtoolsservice/query/data_storage/save_as_excel_writer.py
@@ -35,7 +35,7 @@ class SaveAsExcelWriter(SaveAsWriter):
             self._header_written = True
 
         for loop_index, column_index in enumerate(range(column_start_index, column_end_index)):
-            self._worksheet.write(self._current_row, loop_index, row[column_index].display_value)
+            self._worksheet.write(self._current_row, loop_index, row[column_index].raw_object)
 
         self._current_row += 1
 

--- a/ossdbtoolsservice/query/file_storage_result_set.py
+++ b/ossdbtoolsservice/query/file_storage_result_set.py
@@ -92,16 +92,19 @@ class FileStorageResultSet(ResultSet):
 
     def do_save_as(self, file_path: str, row_start_index: int, row_end_index: int, file_factory: FileStreamFactory, on_success, on_failure) -> None:
 
-        with file_factory.get_writer(file_path) as writer:
-            with file_factory.get_reader(self._output_file_name) as reader:
-                for row_index in range(row_start_index, row_end_index):
-                    row = reader.read_row(self._file_offsets[row_index], row_index, self.columns_info)
-                    writer.write_row(row, self.columns_info)
+        try:
+            with file_factory.get_writer(file_path) as writer:
+                with file_factory.get_reader(self._output_file_name) as reader:
+                    for row_index in range(row_start_index, row_end_index):
+                        row = reader.read_row(self._file_offsets[row_index], row_index, self.columns_info)
+                        writer.write_row(row, self.columns_info)
 
-                writer.complete_write()
+                    writer.complete_write()
 
-                if on_success is not None:
-                    on_success()
+                    if on_success is not None:
+                        on_success()
+        except Exception as e:
+            on_failure(e.strerror if hasattr(e, 'strerror') else e)
 
     def _append_row_to_buffer(self, cursor):
 

--- a/ossdbtoolsservice/query_execution/contracts/save_result_as_request.py
+++ b/ossdbtoolsservice/query_execution/contracts/save_result_as_request.py
@@ -19,6 +19,7 @@ class SaveResultsAsCsvRequestParams(SaveResultsRequestParams):
     def __init__(self):
         super().__init__()
         self.include_headers: bool = None
+        self.delimiter: str = ','
 
 
 class SaveResultsAsJsonRequestParams(SaveResultsRequestParams):

--- a/tests/query/data_storage/test_save_as_csv_writer.py
+++ b/tests/query/data_storage/test_save_as_csv_writer.py
@@ -50,7 +50,7 @@ class TestSaveAsCsvWriter(unittest.TestCase):
         with mock.patch('csv.writer', new=csv_writer_mock):
             self.writer.write_row(self.row, self.columns)
 
-            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=',', quotechar='"', quoting=0)
+            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=',', quotechar='"', quoting=0, lineterminator='\n')
 
             self.assertEqual(writer_mock.writerow.call_count, 2)
             write_row_args = writer_mock.writerow.call_args_list
@@ -68,7 +68,7 @@ class TestSaveAsCsvWriter(unittest.TestCase):
         with mock.patch('csv.writer', new=csv_writer_mock):
             self.writer.write_row(self.row, self.columns)
 
-            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=',', quotechar='"', quoting=0)
+            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=',', quotechar='"', quoting=0, lineterminator='\n')
 
             self.assertEqual(writer_mock.writerow.call_count, 2)
             write_row_args = writer_mock.writerow.call_args_list
@@ -84,7 +84,7 @@ class TestSaveAsCsvWriter(unittest.TestCase):
         with mock.patch('csv.writer', new=csv_writer_mock):
             self.writer.write_row(self.row, self.columns)
 
-            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=';', quotechar='"', quoting=0)
+            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=';', quotechar='"', quoting=0, lineterminator='\n')
 
             self.assertEqual(writer_mock.writerow.call_count, 2)
             write_row_args = writer_mock.writerow.call_args_list

--- a/tests/query/data_storage/test_save_as_csv_writer.py
+++ b/tests/query/data_storage/test_save_as_csv_writer.py
@@ -75,3 +75,19 @@ class TestSaveAsCsvWriter(unittest.TestCase):
 
             self.assertEqual(['Id', 'Valid'], write_row_args[0][0][0])
             self.assertEqual(['1023', 'False'], write_row_args[1][0][0])
+
+    def test_write_row_change_delimiter(self):
+
+        self.request.delimiter = ';'
+        writer_mock = mock.MagicMock()
+        csv_writer_mock = mock.Mock(return_value=writer_mock)
+        with mock.patch('csv.writer', new=csv_writer_mock):
+            self.writer.write_row(self.row, self.columns)
+
+            csv_writer_mock.assert_called_once_with(self.mock_io, delimiter=';', quotechar='"', quoting=0)
+
+            self.assertEqual(writer_mock.writerow.call_count, 2)
+            write_row_args = writer_mock.writerow.call_args_list
+
+            self.assertEqual(['Name', 'Id', 'Valid'], write_row_args[0][0][0])
+            self.assertEqual(['Test', '1023', 'False'], write_row_args[1][0][0])

--- a/tests/query/data_storage/test_save_as_excel_writer.py
+++ b/tests/query/data_storage/test_save_as_excel_writer.py
@@ -89,7 +89,7 @@ class TestSaveAsExcelWriter(unittest.TestCase):
 
         self.assertEqual(1, write_column_value_args[5][0][0])
         self.assertEqual(2, write_column_value_args[5][0][1])
-        self.assertEqual('False', write_column_value_args[5][0][2])
+        self.assertEqual(False, write_column_value_args[5][0][2])
 
     def test_complete_write(self):
         self.writer.complete_write()

--- a/tests/query/data_storage/test_save_as_excel_writer.py
+++ b/tests/query/data_storage/test_save_as_excel_writer.py
@@ -21,9 +21,9 @@ class TestSaveAsExcelWriter(unittest.TestCase):
         self.mock_io = mock.MagicMock()
 
         self.row = [
-            DbCellValue('Test', False, None, 0),
-            DbCellValue(1023, False, None, 0),
-            DbCellValue(False, False, None, 0)
+            DbCellValue('Test', False, 'Test', 0),
+            DbCellValue(1023, False, 1023, 0),
+            DbCellValue(False, False, False, 0)
         ]
 
         name_column = DbColumn()

--- a/tests/query/data_storage/test_save_as_excel_writer.py
+++ b/tests/query/data_storage/test_save_as_excel_writer.py
@@ -85,7 +85,7 @@ class TestSaveAsExcelWriter(unittest.TestCase):
 
         self.assertEqual(1, write_column_value_args[4][0][0])
         self.assertEqual(1, write_column_value_args[4][0][1])
-        self.assertEqual('1023', write_column_value_args[4][0][2])
+        self.assertEqual(1023, write_column_value_args[4][0][2])
 
         self.assertEqual(1, write_column_value_args[5][0][0])
         self.assertEqual(2, write_column_value_args[5][0][1])


### PR DESCRIPTION
Give raw object when saving as excel. Keeps integers as numeric. [318](https://github.com/microsoft/azuredatastudio-postgresql/issues/318)

Fix delimiter [262](https://github.com/microsoft/azuredatastudio-postgresql/issues/262) :
![image](https://github.com/microsoft/pgtoolsservice/assets/69922333/60c0df29-7fcd-4ffb-8bb6-3102e9f8983d)

Fix new lines add in CSV [238](https://github.com/microsoft/azuredatastudio-postgresql/issues/238)
<img width="481" alt="image" src="https://github.com/microsoft/pgtoolsservice/assets/69922333/041f3c4b-167a-4b79-8ecc-8f74fedd173d">

Show error during save fail:
![image](https://github.com/microsoft/pgtoolsservice/assets/69922333/b920a8d1-df7f-4092-a153-336110dc7656)
