### PR TITLE
Schema description endpoint

### DIFF
--- a/ossdbtoolsservice/metadata/contracts/__init__.py
+++ b/ossdbtoolsservice/metadata/contracts/__init__.py
@@ -8,9 +8,10 @@ from ossdbtoolsservice.metadata.contracts.metadata_list_request import (
 from ossdbtoolsservice.metadata.contracts.metadata_schema_request import (
     MetadataSchemaParameters, MetadataSchemaResponse, METADATA_SCHEMA_REQUEST)
 from ossdbtoolsservice.metadata.contracts.object_metadata import MetadataType, ObjectMetadata
+from ossdbtoolsservice.metadata.contracts.schema_metadata import SchemaMetadata
 
 __all__ = [
     'MetadataListParameters', 'MetadataListResponse', 'METADATA_LIST_REQUEST',
     'MetadataSchemaParameters', 'MetadataSchemaResponse', 'METADATA_SCHEMA_REQUEST',
-    'MetadataType', 'ObjectMetadata'
+    'MetadataType', 'ObjectMetadata', 'SchemaMetadata'
 ]

--- a/ossdbtoolsservice/metadata/contracts/__init__.py
+++ b/ossdbtoolsservice/metadata/contracts/__init__.py
@@ -5,9 +5,12 @@
 
 from ossdbtoolsservice.metadata.contracts.metadata_list_request import (
     MetadataListParameters, MetadataListResponse, METADATA_LIST_REQUEST)
+from ossdbtoolsservice.metadata.contracts.metadata_schema_request import (
+    MetadataSchemaParameters, MetadataSchemaResponse, METADATA_SCHEMA_REQUEST)
 from ossdbtoolsservice.metadata.contracts.object_metadata import MetadataType, ObjectMetadata
 
 __all__ = [
     'MetadataListParameters', 'MetadataListResponse', 'METADATA_LIST_REQUEST',
+    'MetadataSchemaParameters', 'MetadataSchemaResponse', 'METADATA_SCHEMA_REQUEST',
     'MetadataType', 'ObjectMetadata'
 ]

--- a/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
+++ b/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
@@ -14,8 +14,8 @@ class MetadataSchemaParameters(Serializable):
 
 
 class MetadataSchemaResponse:
-    def __init__(self, metadata: str):
-        self.metadata: str = metadata
+    def __init__(self, desc: str):
+        self.description: str = desc
 
 
 METADATA_SCHEMA_REQUEST = IncomingMessageConfiguration('metadata/schema', MetadataSchemaParameters)

--- a/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
+++ b/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
@@ -1,0 +1,21 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from ossdbtoolsservice.hosting import IncomingMessageConfiguration
+from ossdbtoolsservice.serialization import Serializable
+
+
+class MetadataSchemaParameters(Serializable):
+
+    def __init__(self):
+        self.owner_uri: str = None
+
+
+class MetadataSchemaResponse:
+    def __init__(self, metadata: str):
+        self.metadata: str = metadata
+
+
+METADATA_SCHEMA_REQUEST = IncomingMessageConfiguration('metadata/sql', MetadataSchemaParameters)

--- a/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
+++ b/ossdbtoolsservice/metadata/contracts/metadata_schema_request.py
@@ -18,4 +18,4 @@ class MetadataSchemaResponse:
         self.metadata: str = metadata
 
 
-METADATA_SCHEMA_REQUEST = IncomingMessageConfiguration('metadata/sql', MetadataSchemaParameters)
+METADATA_SCHEMA_REQUEST = IncomingMessageConfiguration('metadata/schema', MetadataSchemaParameters)

--- a/ossdbtoolsservice/metadata/contracts/schema_metadata.py
+++ b/ossdbtoolsservice/metadata/contracts/schema_metadata.py
@@ -41,6 +41,7 @@ class SchemaMetadata:
         table_name
         \tcolumn_name/type
         \tcolumn_name/type
+
         """)
 
         self.cur.execute(
@@ -68,8 +69,8 @@ class SchemaMetadata:
         for table, column, dt in tables:
             if table != cur_table:
                 cur_table = table
-                results += table
-            results += f"\t{column}/{_pretty_type(dt)}"
+                results += table + "\n"
+            results += f"\t{column}/{_pretty_type(dt)}\n"
 
         return results
 
@@ -79,6 +80,7 @@ class SchemaMetadata:
         table_name
         \tconstraint_def
         \tconstraint_def
+
         """)
 
         self.cur.execute(
@@ -105,8 +107,8 @@ class SchemaMetadata:
         for table, constraint in tables:
             if table != cur_table:
                 cur_table = table
-                results += table
-            results += "\t" + _pretty_constraint(constraint)
+                results += table + "\n"
+            results += "\t" + _pretty_constraint(constraint) + "\n"
 
         return results
 
@@ -116,6 +118,7 @@ class SchemaMetadata:
         table_name
         \ttype (column_name, column_name)
         \ttype (column_name, column_name)
+
         """)
 
         self.cur.execute(
@@ -133,7 +136,7 @@ class SchemaMetadata:
         for table, indx in tables:
             if table != cur_table:
                 cur_table = table
-                results += table
-            results += "\t" + _pretty_index(indx)
+                results += table + "\n"
+            results += "\t" + _pretty_index(indx) + "\n"
 
         return results

--- a/ossdbtoolsservice/metadata/contracts/schema_metadata.py
+++ b/ossdbtoolsservice/metadata/contracts/schema_metadata.py
@@ -1,0 +1,139 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from psycopg import (ClientCursor, OperationalError)
+from textwrap import (dedent)
+import re
+
+def _pretty_type(dt):
+    dt = re.sub('timestamp with time zone', 'timestamptz', dt)
+    dt = re.sub('timestamp without time zone', 'timestamp', dt)
+    dt = re.sub('character varying', 'varchar', dt)
+    dt = re.sub('double precision', 'double', dt)
+    dt = re.sub('boolean', 'bool', dt)
+    dt = re.sub('integer', 'int', dt)
+    return dt.lower()
+
+def _pretty_constraint(constraint):
+    return (constraint.rsplit(')', 1)[0] + ")").lower()
+
+def _pretty_index(indexdef):
+    return indexdef.split(' USING ')[1].lower()
+
+class SchemaMetadata:
+    """Describe the schema to an LLM"""
+
+    def __init__(self, cur: ClientCursor, schema: str = "public"):
+        self.cur = cur
+        self.schema = schema
+
+    def describe(self) -> str:
+        t = self.describe_tables()
+        c = self.describe_constraints()
+        i = self.describe_indexes()
+        return f"## PostgreSQL database schema\n{t}{c}{i}"
+
+    def describe_tables(self) -> str:
+        results = dedent("""
+        ## Tables and columns in the schema, in the form:
+        table_name
+        \tcolumn_name/type
+        \tcolumn_name/type
+        """)
+
+        self.cur.execute(
+        f"""
+        SELECT
+            t.table_name,
+            column_name,
+            data_type
+        FROM
+            information_schema.tables AS t
+            INNER JOIN information_schema.columns AS c
+                ON t.table_name = c.table_name
+        WHERE
+            t.table_schema = '{self.schema}'
+        AND t.table_name NOT LIKE '%\_p%' --exclude partitions
+        AND t.table_name NOT LIKE 'pg\_%' --exclude system tables
+        ORDER BY
+            t.table_name,
+            c.ordinal_position;
+        """
+        )
+        tables = self.cur.fetchall()
+
+        cur_table = None
+        for table, column, dt in tables:
+            if table != cur_table:
+                cur_table = table
+                results += table
+            results += f"\t{column}/{_pretty_type(dt)}"
+
+        return results
+
+    def describe_constraints(self) -> str:
+        results = dedent("""
+        ## Table constraints, in the form:
+        table_name
+        \tconstraint_def
+        \tconstraint_def
+        """)
+
+        self.cur.execute(
+        f"""
+        SELECT
+            t.relname AS table_name,
+            pg_get_constraintdef(c.oid) AS definition
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        WHERE c.contype IN ('p', 'u', 'f')
+            AND t.relname IN (
+                SELECT tablename
+                FROM pg_catalog.pg_tables
+                WHERE schemaname = '{self.schema}'
+                AND tablename NOT LIKE '%\_p%' --exclude partitions
+                AND tablename NOT LIKE 'pg\_%' --exclude system tables
+            )
+        ORDER BY 1, 2;
+        """
+        )
+        tables = self.cur.fetchall()
+
+        cur_table = None
+        for table, constraint in tables:
+            if table != cur_table:
+                cur_table = table
+                results += table
+            results += "\t" + _pretty_constraint(constraint)
+
+        return results
+
+    def describe_indexes(self) -> str:
+        results = dedent("""
+        ## Table indexes, in the form:
+        table_name
+        \ttype (column_name, column_name)
+        \ttype (column_name, column_name)
+        """)
+
+        self.cur.execute(
+        f"""
+        SELECT tablename, indexdef
+        FROM pg_indexes
+        WHERE schemaname = '{self.schema}'
+        AND tablename NOT LIKE '%\_p%' --exclude partitions
+        AND tablename NOT LIKE 'pg\_%' --exclude system tables
+        ORDER BY 1, 2;
+        """
+        )
+        tables = self.cur.fetchall()
+        cur_table = None
+        for table, indx in tables:
+            if table != cur_table:
+                cur_table = table
+                results += table
+            results += "\t" + _pretty_index(indx)
+
+        return results

--- a/ossdbtoolsservice/metadata/metadata_service.py
+++ b/ossdbtoolsservice/metadata/metadata_service.py
@@ -11,7 +11,7 @@ from ossdbtoolsservice.connection.contracts import ConnectionType
 from ossdbtoolsservice.hosting import RequestContext, ServiceProvider
 from ossdbtoolsservice.metadata.contracts import (
     MetadataListParameters, MetadataListResponse, METADATA_LIST_REQUEST, MetadataType, ObjectMetadata,
-    MetadataSchemaParameters, MetadataSchemaResponse, METADATA_SCHEMA_REQUEST)
+    MetadataSchemaParameters, MetadataSchemaResponse, METADATA_SCHEMA_REQUEST, SchemaMetadata)
 from ossdbtoolsservice.utils import constants
 
 # This query collects all the tables, views, and functions in all the schemas in the database(s)?
@@ -116,10 +116,8 @@ class MetadataService:
         # Get current connection
         connection_service = self._service_provider[constants.CONNECTION_SERVICE_NAME]
         connection: ServerConnection = connection_service.get_connection(owner_uri, ConnectionType.DEFAULT)
-        metadata_query = "SELECT version()"
-
-        query_results = connection.execute_query(metadata_query, all=True)
-        return query_results[0][0]
+        schema = SchemaMetadata(connection.cursor(), 'public')
+        return schema.describe()
 
 _METADATA_TYPE_MAP = {
     'f': MetadataType.FUNCTION,

--- a/ossdbtoolsservice/metadata/metadata_service.py
+++ b/ossdbtoolsservice/metadata/metadata_service.py
@@ -88,7 +88,7 @@ class MetadataService:
         except Exception as e:
             if self._service_provider.logger is not None:
                 self._service_provider.logger.exception('Unhandled exception while executing the metadata schema worker thread')
-            request_context.send_error('Unhandled exception while listing metadata: ' + str(e))
+            request_context.send_error('Unhandled exception while getting schema DDL: ' + str(e))
 
     def _list_metadata(self, owner_uri: str) -> List[ObjectMetadata]:
         # Get current connection
@@ -113,8 +113,13 @@ class MetadataService:
         return metadata_list
 
     def _schema_metadata(self, owner_uri: str) -> str:
-        return "Hello world"
+        # Get current connection
+        connection_service = self._service_provider[constants.CONNECTION_SERVICE_NAME]
+        connection: ServerConnection = connection_service.get_connection(owner_uri, ConnectionType.DEFAULT)
+        metadata_query = "SELECT version()"
 
+        query_results = connection.execute_query(metadata_query, all=True)
+        return query_results[0][0]
 
 _METADATA_TYPE_MAP = {
     'f': MetadataType.FUNCTION,

--- a/tests/metadata/test_metadata_service.py
+++ b/tests/metadata/test_metadata_service.py
@@ -115,7 +115,9 @@ class TestMetadataService(unittest.TestCase):
         params = MetadataSchemaParameters()
         params.owner_uri = self.test_uri
 
-        self.metadata_service._handle_metadata_schema_request(request_context, params)
+        mock_thread = MockThread()
+        with mock.patch('threading.Thread', new=mock.Mock(side_effect=mock_thread.initialize_target)):
+            self.metadata_service._handle_metadata_schema_request(request_context, params)
 
         response = request_context.last_response_params
         self.assertIsInstance(response, MetadataSchemaResponse)


### PR DESCRIPTION
Add a `metadata/schema` endpoint which outputs a terse natural-language description of the public schema.