### PR TITLE
Fix edge cases handling for date datetime timestamp

### DIFF
--- a/ossdbtoolsservice/driver/types/adapter.py
+++ b/ossdbtoolsservice/driver/types/adapter.py
@@ -1,0 +1,71 @@
+from datetime import date, datetime
+from datetime import time
+# Subclass existing adapters so that the base case is handled normally.
+from psycopg.types.datetime import DateLoader, DateDumper, TimestampLoader, TimeLoader
+
+
+class InfDateDumper(DateDumper):
+    def dump(self, obj):
+        if obj == date.max:
+            return b"infinity"
+        elif obj == date.min:
+            return b"-infinity"
+        else:
+            return super().dump(obj)
+
+
+class InfTimeLoader(TimeLoader):
+    def load(self, data):
+        s = bytes(data).decode("utf8", "replace")
+        if s == "24:00:00":
+            return time(0, 0, 0)  # or whatever representation you prefer for 24:00
+        else:
+            return super().load(data)
+
+
+class InfDateLoader(DateLoader):
+    def load(self, data):
+        s = bytes(data).decode("utf8", "replace")
+        if s == "infinity" or (s and len(s.split()[0]) > 10):
+            return date.max
+        elif s == "-infinity" or "BC" in s:
+            return date.min
+        else:
+            return super().load(data)
+
+
+class InfTimestampLoader(TimestampLoader):
+    def load(self, data):
+        s = bytes(data).decode("utf8", "replace")
+
+        # Check for the special 'infinity' values first
+        if s.startswith("infinity"):
+            return datetime.max
+        elif s.startswith("-infinity") or "BC" in s:
+            return datetime.min
+
+        # Use _order attribute to determine the year's position
+        parts = s.split('-')
+        if self._order == self._ORDER_YMD:
+            year = int(parts[0])
+        elif self._order == self._ORDER_DMY:
+            year = int(parts[2])
+        elif self._order == self._ORDER_MDY:
+            # MDY might look like MM-DD-YYYY
+            # So you need to get the YYYY from the date-time split
+            year = int(s.split(' ')[0].split('-')[2])
+        else:
+            # Raise an exception or handle unknown formats
+            year = None
+
+        if year and year > 9999:
+            return datetime.max
+        else:
+            return super().load(data)
+
+
+def addAdapters(conn):
+    conn.adapters.register_dumper(date, InfDateDumper)
+    conn.adapters.register_loader("date", InfDateLoader)
+    conn.adapters.register_loader("timestamp", InfTimestampLoader)
+    conn.adapters.register_loader("time", InfTimeLoader)

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-
 from enum import Enum
 from typing import List  # noqa
 from datetime import datetime
@@ -119,6 +118,7 @@ class Batch:
             self._batch_events._on_execution_started(self)
 
         cursor = self.get_cursor(conn)
+
         conn.connection.add_notice_handler(lambda msg: self.notice_handler(msg, conn))
 
         if self.batch_text.startswith('begin') and conn.transaction_in_trans:

--- a/tests/connection/test_adapters.py
+++ b/tests/connection/test_adapters.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+from datetime import date, datetime, time
+
+from ossdbtoolsservice.driver.types.adapter import InfDateDumper, InfDateLoader, InfTimestampLoader, InfTimeLoader
+
+
+class TestAdapters(unittest.TestCase):
+
+    def test_InfDateDumper(self):
+        with patch.object(InfDateDumper, '__init__', lambda self, cls: None):
+            adapter = InfDateDumper(None)
+            self.assertEqual(adapter.dump(date.max), b"infinity")
+            self.assertEqual(adapter.dump(date.min), b"-infinity")
+            self.assertEqual(adapter.dump(date(2021, 1, 1)), b"2021-01-01")
+
+    def test_InfDateLoader(self):
+        with patch.object(InfDateLoader, '__init__', lambda self, cls: None):
+            adapter = InfDateLoader(None)
+            adapter._order = adapter._ORDER_YMD
+            self.assertEqual(adapter.load(b"infinity"), date.max)
+            self.assertEqual(adapter.load(b"-infinity"), date.min)
+            self.assertEqual(adapter.load(b"2000 BC"), date.min)
+            self.assertEqual(adapter.load(b"2021-01-01"), date(2021, 1, 1))
+
+    def test_InfTimestampLoader(self):
+        with patch.object(InfTimestampLoader, '__init__', lambda self, cls: None):
+            adapter = InfTimestampLoader(None)
+            adapter._order = adapter._ORDER_YMD
+            self.assertEqual(adapter.load(b"infinity"), datetime.max)
+            self.assertEqual(adapter.load(b"-infinity"), datetime.min)
+            self.assertEqual(adapter.load(b"2000-01-01 BC 12:00:00"), datetime.min)
+            self.assertEqual(adapter.load(b"2021-01-01 12:00:00"), datetime(2021, 1, 1, 12, 0))
+
+    def test_InfTimeLoader(self):
+        with patch.object(InfTimeLoader, '__init__', lambda self, cls: None):
+            adapter = InfTimeLoader(None)
+            self.assertEqual(adapter.load(b"24:00:00"), time(0, 0, 0))
+            self.assertEqual(adapter.load(b"12:00:00"), time(12, 0, 0))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/language/test_language_service.py
+++ b/tests/language/test_language_service.py
@@ -301,7 +301,7 @@ class TestLanguageService(unittest.TestCase):
         expected_output = '\n'.join([
             'SELECT *',
             'FROM foo',
-            'WHERE id IN',
+            'WHERE id in',
             '\t\t\t\t(SELECT id',
             '\t\t\t\t\tFROM bar);'
         ])
@@ -348,7 +348,7 @@ class TestLanguageService(unittest.TestCase):
         expected_output = '\n'.join([
             'SELECT *',
             'FROM foo',
-            'WHERE id IN',
+            'WHERE id in',
             '\t\t\t\t(SELECT id',
             '\t\t\t\t\tFROM bar);'
         ])

--- a/tests/language/test_language_service.py
+++ b/tests/language/test_language_service.py
@@ -261,7 +261,7 @@ class TestLanguageService(unittest.TestCase):
         """
         Test that the format codepath succeeds even if the configuration options aren't defined
         """
-        input_text = 'select * from foo where id in (select id from bar);'
+        input_text = 'select * from foo where id IN (select id from bar);'
 
         context: RequestContext = utils.MockRequestContext()
 
@@ -301,7 +301,7 @@ class TestLanguageService(unittest.TestCase):
         expected_output = '\n'.join([
             'SELECT *',
             'FROM foo',
-            'WHERE id in',
+            'WHERE id IN',
             '\t\t\t\t(SELECT id',
             '\t\t\t\t\tFROM bar);'
         ])
@@ -348,7 +348,7 @@ class TestLanguageService(unittest.TestCase):
         expected_output = '\n'.join([
             'SELECT *',
             'FROM foo',
-            'WHERE id in',
+            'WHERE id IN',
             '\t\t\t\t(SELECT id',
             '\t\t\t\t\tFROM bar);'
         ])

--- a/tests/query_execution/test_pg_query_execution_service.py
+++ b/tests/query_execution/test_pg_query_execution_service.py
@@ -16,7 +16,6 @@ from unittest import mock
 import psycopg
 from dateutil import parser
 
-import tests.utils as utils
 from ossdbtoolsservice.connection import ConnectionInfo, ConnectionService
 from ossdbtoolsservice.connection.contracts import (ConnectionDetails,
                                                     ConnectionType)
@@ -48,6 +47,7 @@ from ossdbtoolsservice.query_execution.query_execution_service import (
 from ossdbtoolsservice.utils import constants
 from tests.integration import get_connection_details, integration_test
 from tests.pgsmo_tests.utils import MockPGServerConnection
+import tests.utils as utils
 
 
 class TestQueryService(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -120,13 +120,17 @@ class MockPsycopgConnection(object):
         self.pgconn = mock.Mock()
         self.info = MockConnectionInfo(dsn_parameters, self.server_version)
 
-        self._adapters: Optional[AdaptersMap] = None
+        self._adapters: Optional[AdaptersMap] = mock.Mock()
         self.notice_handlers: List[NoticeHandler] = []
 
     @property
     def closed(self):
         """Mock for the connection's closed property"""
         return self.close.call_count > 0
+
+    @property
+    def adapters(self) -> AdaptersMap:
+        return self._adapters
 
     def get_dsn_parameters(self):
         """Mock for the connection's get_dsn_parameters method"""


### PR DESCRIPTION
Fix for https://github.com/microsoft/azuredatastudio-postgresql/issues/457

Add customized adapters to handle timestamp edge cases that are outside of Python's date datatype's min and max values
Dates smaller than Min or bigger than max values will be represented in Python's date datatype's min and max values

table
<img width="598" alt="image" src="https://github.com/microsoft/pgtoolsservice/assets/69321306/73b7d924-33fb-4fd9-a724-a4a55ac7d598">

ADS
<img width="631" alt="image" src="https://github.com/microsoft/pgtoolsservice/assets/69321306/42a947c0-c395-4010-af51-69facb0d0f6e">

