### PR TITLE
[WIP] Execute query in one shot to improve query execution performance

### DIFF
--- a/ossdbtoolsservice/driver/types/driver.py
+++ b/ossdbtoolsservice/driver/types/driver.py
@@ -63,6 +63,11 @@ class ServerConnection(ABC):
 
     @property
     @abstractmethod
+    def transaction_is_active(self) -> bool:
+        """Returns bool indicating if transaction is active"""
+
+    @property
+    @abstractmethod
     def transaction_in_error(self) -> bool:
         """Returns bool indicating if transaction is in error"""
 
@@ -70,6 +75,11 @@ class ServerConnection(ABC):
     @abstractmethod
     def transaction_is_idle(self) -> bool:
         """Returns bool indicating if transaction is currently idle"""
+
+    @property
+    @abstractmethod
+    def transaction_in_unknown(self) -> bool:
+        """Returns bool indicating if transaction is active"""
 
     @property
     @abstractmethod
@@ -177,6 +187,12 @@ class ServerConnection(ABC):
     def close(self):
         """
         Closes this current connection.
+        """
+
+
+    def transaction_status(self):
+        """
+        Gets the current transaction status if it exists
         """
 
     @abstractmethod

--- a/ossdbtoolsservice/driver/types/psycopg_driver.py
+++ b/ossdbtoolsservice/driver/types/psycopg_driver.py
@@ -151,6 +151,11 @@ class PostgreSQLConnection(ServerConnection):
         return self._database_error
 
     @property
+    def transaction_is_active(self) -> bool:
+        """Returns bool indicating if transaction is active"""
+        return self._conn.info.transaction_status is TransactionStatus.ACTIVE
+
+    @property
     def transaction_in_error(self) -> bool:
         """Returns bool indicating if transaction is in error"""
         return self._conn.info.transaction_status is TransactionStatus.INERROR or self._transaction_in_error is TransactionStatus.INERROR
@@ -159,6 +164,11 @@ class PostgreSQLConnection(ServerConnection):
     def transaction_is_idle(self) -> bool:
         """Returns bool indicating if transaction is currently idle"""
         return self._conn.info.transaction_status is TransactionStatus.IDLE
+    
+    @property
+    def transaction_in_unknown(self) -> bool:
+        """Returns bool indicating if transaction is in unknown state"""
+        return self._conn.info.transaction_status is TransactionStatus.UNKNOWN
 
     @property
     def transaction_in_trans(self) -> bool:
@@ -314,6 +324,14 @@ class PostgreSQLConnection(ServerConnection):
         Closes this current connection.
         """
         self._conn.close()
+
+    def transaction_status(self):
+        """
+        Gets the current transaction status if it exists
+        """
+        if self._conn and self._conn.info:
+            return self._conn.info.transaction_status
+        return None
 
     def set_transaction_in_error(self):
         """

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -202,13 +202,13 @@ def create_result_set(storage_type: ResultSetStorageType, result_set_id: int, ba
 
 
 def create_batch(batch_text: str, ordinal: int, selection: SelectionData, batch_events: BatchEvents, storage_type: ResultSetStorageType) -> Batch:
-    sql = sqlparse.parse(batch_text)
-    statement = sql[0]
+    # sql = sqlparse.parse(batch_text)
+    # statement = sql[0]
 
-    if statement.get_type().lower() == 'select':
-        into_checker = [True for token in statement.tokens if token.normalized == 'INTO']
-        cte_checker = [True for token in statement.tokens if token.ttype == sqlparse.tokens.Keyword.CTE]
-        if len(into_checker) == 0 and len(cte_checker) == 0:  # SELECT INTO and CTE keywords can't be used in named cursor
-            return SelectBatch(batch_text, ordinal, selection, batch_events, storage_type)
+    # if statement.get_type().lower() == 'select':
+    #     into_checker = [True for token in statement.tokens if token.normalized == 'INTO']
+    #     cte_checker = [True for token in statement.tokens if token.ttype == sqlparse.tokens.Keyword.CTE]
+    #     if len(into_checker) == 0 and len(cte_checker) == 0:  # SELECT INTO and CTE keywords can't be used in named cursor
+    #         return SelectBatch(batch_text, ordinal, selection, batch_events, storage_type)
 
     return Batch(batch_text, ordinal, selection, batch_events, storage_type)

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -201,7 +201,7 @@ def create_result_set(storage_type: ResultSetStorageType, result_set_id: int, ba
     return InMemoryResultSet(result_set_id, batch_id)
 
 
-def create_batch(batch_text: str, ordinal: int, selection: SelectionData, batch_events: BatchEvents, storage_type: ResultSetStorageType) -> Batch:
+def create_batch(batch_text: str, ordinal: int, selection: SelectionData, batch_events: BatchEvents, storage_type: ResultSetStorageType, select_batch: bool = False) -> Batch:
     # sql = sqlparse.parse(batch_text)
     # statement = sql[0]
 
@@ -210,5 +210,6 @@ def create_batch(batch_text: str, ordinal: int, selection: SelectionData, batch_
     #     cte_checker = [True for token in statement.tokens if token.ttype == sqlparse.tokens.Keyword.CTE]
     #     if len(into_checker) == 0 and len(cte_checker) == 0:  # SELECT INTO and CTE keywords can't be used in named cursor
     #         return SelectBatch(batch_text, ordinal, selection, batch_events, storage_type)
-
+    if select_batch:
+        return SelectBatch(batch_text, ordinal, selection, batch_events, storage_type)
     return Batch(batch_text, ordinal, selection, batch_events, storage_type)

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import psycopg
 import uuid
 import sqlparse
+from sqlparse.sql import Statement
 
 from ossdbtoolsservice.driver import ServerConnection
 from ossdbtoolsservice.utils.time import get_time_str, get_elapsed_time_str
@@ -42,7 +43,7 @@ class Batch:
 
     def __init__(
             self,
-            batch_text: str,
+            statement: Statement,
             ordinal: int,
             selection: SelectionData,
             batch_events: BatchEvents = None,
@@ -50,7 +51,8 @@ class Batch:
     ) -> None:
         self.id = ordinal
         self.selection = selection
-        self.batch_text = batch_text
+        self.statement = statement
+        self.batch_text = str(statement)
         self.status_message: str = None
 
         self._execution_start_time: datetime = None
@@ -201,14 +203,11 @@ def create_result_set(storage_type: ResultSetStorageType, result_set_id: int, ba
     return InMemoryResultSet(result_set_id, batch_id)
 
 
-def create_batch(batch_text: str, ordinal: int, selection: SelectionData, batch_events: BatchEvents, storage_type: ResultSetStorageType) -> Batch:
-    sql = sqlparse.parse(batch_text)
-    statement = sql[0]
-
+def create_batch(statement: Statement, ordinal: int, selection: SelectionData, batch_events: BatchEvents, storage_type: ResultSetStorageType) -> Batch:
     if statement.get_type().lower() == 'select':
         into_checker = [True for token in statement.tokens if token.normalized == 'INTO']
         cte_checker = [True for token in statement.tokens if token.ttype == sqlparse.tokens.Keyword.CTE]
         if len(into_checker) == 0 and len(cte_checker) == 0:  # SELECT INTO and CTE keywords can't be used in named cursor
-            return SelectBatch(batch_text, ordinal, selection, batch_events, storage_type)
+            return SelectBatch(statement, ordinal, selection, batch_events, storage_type)
 
-    return Batch(batch_text, ordinal, selection, batch_events, storage_type)
+    return Batch(statement, ordinal, selection, batch_events, storage_type)

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -107,50 +107,6 @@ class Batch:
     def get_cursor(self, connection: ServerConnection):
         return connection.cursor()
 
-    def execute(self, conn: ServerConnection) -> None:
-        """
-        Execute the batch using a cursor retrieved from the given connection
-
-        :raises DatabaseError: if an error is encountered while running the batch's query
-        """
-        self._execution_start_time = datetime.now()
-
-        if self._batch_events and self._batch_events._on_execution_started:
-            self._batch_events._on_execution_started(self)
-
-        cursor = self.get_cursor(conn)
-
-        conn.connection.add_notice_handler(lambda msg: self.notice_handler(msg, conn))
-
-        if self.batch_text.startswith('begin') and conn.transaction_in_trans:
-            self._notices.append('WARNING: there is already a transaction in progress')
-
-        try:
-            cursor.execute(self.batch_text)
-
-            # Commit the transaction if autocommit is True
-            if conn.autocommit:
-                conn.commit()
-
-            self.after_execute(cursor)
-        except psycopg.DatabaseError as e:
-            self._has_error = True
-            conn.set_transaction_in_error()
-            raise e
-        finally:
-            if cursor and cursor.statusmessage is not None:
-                self.status_message = cursor.statusmessage
-            # We are doing this because when the execute fails for named cursors
-            # cursor is not activated on the server which results in failure on close
-            # Hence we are checking if the cursor was really executed for us to close it
-            if cursor and cursor.rowcount != -1 and cursor.rowcount is not None:
-                cursor.close()
-            self._has_executed = True
-            self._execution_end_time = datetime.now()
-
-            if self._batch_events and self._batch_events._on_execution_completed:
-                self._batch_events._on_execution_completed(self)
-
     def after_execute(self, cursor) -> None:
         if cursor.description is not None:
             self.create_result_set(cursor)

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -180,16 +180,26 @@ def compute_selection_data_for_batches(batches: List[str], full_text: str) -> Li
     # Iterate through the batches to build selection data
     selection_data: List[SelectionData] = []
     search_offset = 0
+    line_map_keys = sorted(line_map.keys())
+    l, r = 0, 0
+    start_line_index, end_line_index = 0, 0
     for batch in batches:
         # Calculate the starting line number and column
-        start_index = full_text.index(batch, search_offset)
-        start_line_index = max(filter(lambda line_index: line_index <= start_index, line_map.keys()))
-        start_line_num = line_map[start_line_index]
-        start_col_num = start_index - start_line_index
+        start_index = full_text.index(batch, search_offset) # batch start index
+        # start_line_index = max(filter(lambda line_index: line_index <= start_index, line_map_keys)) # find the character index of the batch start line
+        while l < len(line_map_keys) and line_map_keys[l] <= start_index:
+            start_line_index = line_map_keys[l]
+            l += 1
+
+        start_line_num = line_map[start_line_index] # map that to the line number
+        start_col_num = start_index - start_line_index 
 
         # Calculate the ending line number and column
         end_index = start_index + len(batch)
-        end_line_index = max(filter(lambda line_index: line_index < end_index, line_map.keys()))
+        # end_line_index = max(filter(lambda line_index: line_index < end_index, line_map_keys))
+        while r < len(line_map_keys) and line_map_keys[r] < end_index:
+            end_line_index = line_map_keys[r]
+            r += 1
         end_line_num = line_map[end_line_index]
         end_col_num = end_index - end_line_index
 

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Callable, Dict, List, Optional  # noqa
 
 import sqlparse
+from sqlparse.sql import Statement
 from ossdbtoolsservice.driver import ServerConnection
 from ossdbtoolsservice.query import Batch, BatchEvents, create_batch, ResultSetStorageType
 from ossdbtoolsservice.query.contracts import SaveResultsRequestParams, SelectionData
@@ -64,10 +65,11 @@ class Query:
         self.is_canceled = False
 
         # Initialize the batches
-        statements = sqlparse.split(query_text)
+        statements = sqlparse.parse(query_text)
         selection_data = compute_selection_data_for_batches(statements, query_text)
 
-        for index, batch_text in enumerate(statements):
+        for index, batch in enumerate(statements):
+            batch_text = str(batch)
             # Skip any empty text
             formatted_text = sqlparse.format(batch_text, strip_comments=True).strip()
             if not formatted_text or formatted_text == ';':
@@ -89,7 +91,7 @@ class Query:
                 self._user_transaction = True
 
             batch = create_batch(
-                sql_statement_text,
+                batch,
                 len(self.batches),
                 selection_data[index],
                 query_events.batch_events,
@@ -168,7 +170,7 @@ class Query:
         self.batches[params.batch_index].save_as(params, file_factory, on_success, on_failure)
 
 
-def compute_selection_data_for_batches(batches: List[str], full_text: str) -> List[SelectionData]:
+def compute_selection_data_for_batches(batches: List[Statement], full_text: str) -> List[SelectionData]:
     # Map the starting index of each line to the line number
     line_map: Dict[int, int] = {}
     search_offset = 0
@@ -181,14 +183,15 @@ def compute_selection_data_for_batches(batches: List[str], full_text: str) -> Li
     selection_data: List[SelectionData] = []
     search_offset = 0
     for batch in batches:
+        batch_text = str(batch)
         # Calculate the starting line number and column
-        start_index = full_text.index(batch, search_offset)
+        start_index = full_text.index(batch_text, search_offset)
         start_line_index = max(filter(lambda line_index: line_index <= start_index, line_map.keys()))
         start_line_num = line_map[start_line_index]
         start_col_num = start_index - start_line_index
 
         # Calculate the ending line number and column
-        end_index = start_index + len(batch)
+        end_index = start_index + len(batch_text)
         end_line_index = max(filter(lambda line_index: line_index < end_index, line_map.keys()))
         end_line_num = line_map[end_line_index]
         end_col_num = end_index - end_line_index

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -13,6 +13,7 @@ from ossdbtoolsservice.query import Batch, BatchEvents, create_batch, ResultSetS
 from ossdbtoolsservice.query.contracts import SaveResultsRequestParams, SelectionData
 from ossdbtoolsservice.query.data_storage import FileStreamFactory
 import psycopg
+from utils import constants
 
 
 class QueryEvents:
@@ -61,49 +62,27 @@ class Query:
         self._user_transaction = False
         self._current_batch_index = 0
         self._batches: List[Batch] = []
+        self._notices: List[str] = []
         self._execution_plan_options = query_execution_settings.execution_plan_options
         self._query_events = query_events
         self._query_execution_settings = query_execution_settings
 
         self.is_canceled = False
+        # Use the same selection data for all batches. We want to avoid parsing and splitting into separate SQL statements
         self.selection_data = compute_selection_data_for_batches([self.query_text], self.query_text)[0]
 
-        # Initialize the batches
-        # statements = sqlparse.split(query_text)
-        # selection_data = compute_selection_data_for_batches([query_text], query_text)
-
-        # # for index, batch_text in enumerate(statements):
-        # index = 0
-        # batch_text = query_text
-        # # Skip any empty text
-        # # formatted_text = sqlparse.format(batch_text, strip_comments=True).strip()
-        # # if not formatted_text or formatted_text == ';':
-        # #     return None
-        # formatted_text = batch_text
-
-        # sql_statement_text = batch_text
-
         # # Create and save the batch
-        # if bool(self._execution_plan_options):
-        #     if self._execution_plan_options.include_estimated_execution_plan_xml:
-        #         sql_statement_text = Query.EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
-        #     elif self._execution_plan_options.include_actual_execution_plan_xml:
-        #         self._disable_auto_commit = True
-        #         sql_statement_text = Query.ANALYZE_EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
+        if bool(self._execution_plan_options):
+            if self._execution_plan_options.include_estimated_execution_plan_xml:
+                sql_statement_text = Query.EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
+            elif self._execution_plan_options.include_actual_execution_plan_xml:
+                self._disable_auto_commit = True
+                sql_statement_text = Query.ANALYZE_EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
 
-        # # Check if user defined transaction
-        # if formatted_text.lower().startswith('begin'):
-        #     self._disable_auto_commit = True
-        #     self._user_transaction = True
-
-        # batch = create_batch(
-        #     sql_statement_text,
-        #     len(self.batches),
-        #     selection_data[index],
-        #     query_events.batch_events,
-        #     query_execution_settings.result_set_storage_type)
-
-        # self._batches.append(batch)
+        # Check if user defined transaction
+        if self.query_text.lower().startswith('begin'):
+            self._disable_auto_commit = True
+            self._user_transaction = True
 
     @property
     def owner_uri(self) -> str:
@@ -156,19 +135,13 @@ class Query:
             if self._disable_auto_commit and connection.transaction_is_idle:
                 connection.autocommit = False
 
-            # for batch_index, batch in enumerate(self._batches):
-            #     self._current_batch_index = batch_index
-
-            #     if self.is_canceled:
-            #         break
-
             # Start a cursor block
             batch_events: BatchEvents = None
             if self.query_events is not None and self.query_events.batch_events is not None:
                 batch_events = self.query_events.batch_events
+            
+            connection.connection.add_notice_handler(lambda msg: self.notice_handler(msg, connection))
             with connection.cursor() as cur:
-                connection.connection.add_notice_handler(lambda msg: self.notice_handler(msg, connection))
-                batch_ordinal = 0
                 start_time = datetime.now()
 
                 try:
@@ -183,44 +156,34 @@ class Query:
                     raise e
 
                 curr_resultset = True
-                while curr_resultset:
-                    batch_obj = create_batch(
-                        self.query_text,
-                        batch_ordinal,
-                        self.selection_data,
-                        self.query_events.batch_events,
-                        self.query_execution_settings.result_set_storage_type
-                    )
+                while curr_resultset and len(self.batches) <= constants.MAX_BATCH_RESULT_MESSAGES:
                     # Break if canceled
                     if self.is_canceled:
                         break
 
-                    # Only set end execution time to first batch summary as we cannot collect individual statement execution times
-                    batch_obj._execution_start_time = start_time
-                    if batch_ordinal == 0:
-                        batch_obj._execution_end_time = end_time
+                    # Create and append a new batch object
+                    batch_obj = self.create_next_batch(self.current_batch_index, (start_time, end_time), batch_events)
 
-                    # Call start callback
-                    if batch_events and batch_events._on_execution_started:
-                        batch_events._on_execution_started(batch_obj)
-
+                    # Create the result set if necessary and set to _has_executed
                     batch_obj.after_execute(cur)
-
                     batch_obj._has_executed = True
-
-                    # Call Completed callback
-                    if batch_events and batch_events._on_execution_completed:
-                        batch_events._on_execution_completed(batch_obj)
 
                     if cur and cur.statusmessage is not None:
                         batch_obj.status_message = cur.statusmessage
 
-                    # Append the batch object and update while loop values
-                    self.batches.append(batch_obj)
-                    self._current_batch_index = batch_ordinal
+                    # Update while loop values
                     curr_resultset = cur.nextset()
-                    batch_ordinal += 1
-
+                    self._current_batch_index += 1
+                    
+                    # Call Completed callback
+                    if batch_events and batch_events._on_execution_completed:
+                        if not curr_resultset or len(self.batches) >= constants.MAX_BATCH_RESULT_MESSAGES:
+                            batch_obj._notices = self._notices
+                            batch_obj.notices.append(f"WARNING: This query has reached the max limit of {constants.MAX_BATCH_RESULT_MESSAGES} results. The rest of the query has been executed, but furthter results will not be shown")
+                            batch_events._on_execution_completed(batch_obj)
+                            break
+                        else:
+                            batch_events._on_execution_completed(batch_obj)
 
         finally:
             # We can only set autocommit when the connection is open.
@@ -230,33 +193,41 @@ class Query:
                 self._disable_auto_commit = False
             self._execution_state = ExecutionState.EXECUTED
 
-    def handle_database_error_during_execute(self, conn: ServerConnection, execution_times: Tuple[datetime, datetime], batch_events: BatchEvents):
+    def create_next_batch(self, ordinal: int, execution_times: Tuple[datetime, datetime], batch_events: BatchEvents, empty_selection_data = False):
         start_time, end_time = execution_times
         batch_obj = create_batch(
                         self.query_text,
-                        0,
+                        self.current_batch_index,
                         self.selection_data,
                         self.query_events.batch_events,
                         self.query_execution_settings.result_set_storage_type
                     )
+        self.batches.append(batch_obj)
+
+        # Only set end execution time to first batch summary as we cannot collect individual statement execution times
         batch_obj._execution_start_time = start_time
-        batch_obj._execution_end_time = end_time
+        if self.current_batch_index == 0:
+            batch_obj._execution_end_time = end_time
 
         # Call start callback
         if batch_events and batch_events._on_execution_started:
             batch_events._on_execution_started(batch_obj)
+        return batch_obj
+
+    def handle_database_error_during_execute(self, conn: ServerConnection, execution_times: Tuple[datetime, datetime], batch_events: BatchEvents):
+        batch_obj = self.create_next_batch(0, execution_times, batch_events)
 
         batch_obj._has_error = True
         self.batches.append(batch_obj)
         self._current_batch_index = 0
         conn.set_transaction_in_error()
     
-    def notice_handler(self, notice: str, conn: ServerConnection):
-        if self.batches and len(self.batches) > 0:
+    def notice_handler(self, notice: psycopg.errors.Diagnostic, conn: ServerConnection):
+            # Add notices to last batch element
             if not conn.user_transaction:
-                self.batches[self.current_batch_index]._notices.append('{0}: {1}'.format(notice.severity, notice.message_primary))
+                self._notices.append('{0}: {1}'.format(notice.severity, notice.message_primary))
             elif not notice.message_primary == 'there is already a transaction in progress':
-                self.batches[self.current_batch_index].append('WARNING: {0}'.format(notice.message_primary))
+                self._notices.append('WARNING: {0}'.format(notice.message_primary))
 
     def get_subset(self, batch_index: int, start_index: int, end_index: int):
         if batch_index < 0 or batch_index >= len(self._batches):

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -172,6 +172,8 @@ class Query:
                 start_time = datetime.now()
 
                 try:
+                    if self.is_canceled:
+                        return
                     cur.execute(self.query_text)
                     end_time = datetime.now()
                 except psycopg.DatabaseError as e:
@@ -189,6 +191,9 @@ class Query:
                         self.query_events.batch_events,
                         self.query_execution_settings.result_set_storage_type
                     )
+                    # Break if canceled
+                    if self.is_canceled:
+                        break
 
                     # Only set end execution time to first batch summary as we cannot collect individual statement execution times
                     batch_obj._execution_start_time = start_time

--- a/ossdbtoolsservice/utils/constants.py
+++ b/ossdbtoolsservice/utils/constants.py
@@ -14,6 +14,10 @@ SUPPORTED_PROVIDERS = [PG_PROVIDER_NAME]
 COSMOS_PG_DEFAULT_DB = "COSMOSPGSQL"
 PG_DEFAULT_DB = PG_PROVIDER_NAME
 
+# Max number of results that will be shown from a query's batch results. Will show only first 100 result messages.
+# TODO: Show LAST 100 result messages
+MAX_BATCH_RESULT_MESSAGES = 100
+
 DEFAULT_DB = {
     PG_DEFAULT_DB: "postgres",
     COSMOS_PG_DEFAULT_DB: "citus"


### PR DESCRIPTION
Main Changes:
- Execute query in one shot to improve performance
- Follow pgAdmin4 by using a single execute call (however, we are using the synchronous psycopg execute methods)
- No longer uses sqlparse for any parsing, significantly increasing execution speed

Caveats:
- Only shows results from first 100 statements
- Every batch says "Started executing query on Line 1" because selection data cannot be null. Default to selecting the entire query
- All notices show up in the last batch result message (i.e. "schema already exists, skipping", "schema does not exist, skipping", etc.)

Todo:
- Remove sqlparse from requirements.txt
- Style check
- Tests. May need to write new ones 
- Show LAST 100 results instead of first 100 results
- Give indicator for when the connection is in an active transaction state (enhancement)
- Allow for autocommit to be turned off (indicator for active transaction must be there for this to be useful to customers) (enhancement)
- If possible to do without parsing, figure out correct selection data. May not be possible (enhancement)