### PR TITLE
Use correct arg name for Materialized View scripting templates

### DIFF
--- a/pgsmo/objects/view/materialized_view_templates/pg/9.3_plus/properties.sql
+++ b/pgsmo/objects/view/materialized_view_templates/pg/9.3_plus/properties.sql
@@ -15,7 +15,7 @@ SELECT
     CASE WHEN length(spcname) > 0 THEN spcname ELSE
         (SELECT sp.spcname FROM pg_database dtb
         JOIN pg_tablespace sp ON dtb.dattablespace=sp.oid
-        WHERE dtb.oid = {{ did }}::oid)
+        WHERE dtb.oid = {{ oid }}::oid)
     END as spcname,
     c.relacl,
     nsp.nspname as schema,

--- a/pgsmo/objects/view/materialized_view_templates/pg/9.4_plus/properties.sql
+++ b/pgsmo/objects/view/materialized_view_templates/pg/9.4_plus/properties.sql
@@ -15,7 +15,7 @@ SELECT
     CASE WHEN length(spcname) > 0 THEN spcname ELSE
         (SELECT sp.spcname FROM pg_database dtb
         JOIN pg_tablespace sp ON dtb.dattablespace=sp.oid
-        WHERE dtb.oid = {{ did }}::oid)
+        WHERE dtb.oid = {{ oid }}::oid)
     END as spcname,
     c.relacl,
     nsp.nspname as schema,

--- a/pgsmo/objects/view/materialized_view_templates/ppas/9.3_plus/properties.sql
+++ b/pgsmo/objects/view/materialized_view_templates/ppas/9.3_plus/properties.sql
@@ -9,7 +9,7 @@ SELECT
     CASE WHEN length(spcname) > 0 THEN spcname ELSE
         (SELECT sp.spcname FROM pg_database dtb
         JOIN pg_tablespace sp ON dtb.dattablespace=sp.oid
-        WHERE dtb.oid = {{ did }}::oid)
+        WHERE dtb.oid = {{ oid }}::oid)
     END as spcname,
     c.relacl,
     nsp.nspname as schema,


### PR DESCRIPTION
The value `did` was not passed into the template context, and it was expecting the value `oid` which is provided. Updating the template prevents a syntax error from the empty render caste to ::oid and now MV Create scripting works.