### PR TITLE
Add connection option for AuthenticationType

### DIFF
--- a/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
+++ b/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
@@ -53,6 +53,20 @@ pg_conn_provider_opts = ConnectionProviderOptions([
         group_name='Security'
     ),
     ConnectionOption(
+        name='authenticationType',
+        display_name='Authentication Type',
+        description='Specifies the method of authenticating with PostgreSQL Server',
+        value_type=ConnectionOption.VALUE_TYPE_CATEGORY,
+        special_value_type=ConnectionOption.SPECIAL_VALUE_AUTH_TYPE,
+        is_identity=True,
+        is_required=True,
+        category_values=[
+            CategoryValue('Password', 'SqlLogin'),
+            CategoryValue('Entra Auth', 'AzureMFA')
+        ],
+        group_name='Security',
+    ),
+    ConnectionOption(
         name='azureAccountToken',
         display_name='Access Token',
         description='Indicates an Active Directory access token to be used when connecting to the data source',


### PR DESCRIPTION
This option is used for clients to generate and validate UIs for different methods to authenticate with.

Implementation similar to STS https://github.com/microsoft/sqltoolsservice/blob/9cb8082c62dea05102e47b18efd958f11e8dabc2/src/Microsoft.SqlTools.ServiceLayer/Connection/ConnectionProviderOptionsHelper.cs#L66C13-L82C23
