### PR TITLE
Rm code signing from pullrequest build

### DIFF
--- a/.pipeline/build_pullrequest.yml
+++ b/.pipeline/build_pullrequest.yml
@@ -30,7 +30,6 @@ pool:
   vmImage: $(imageName)
 steps:
   - template: templates/build.yml
-  - template: templates/code-sign.yml
   - task: PowerShell@1
     displayName: Download Postgres windows
     condition: eq(variables.platform, 'windows')


### PR DESCRIPTION
Making this change in the PR build because:
- PR builds are not meant for distribution or use, only to confirm that it compiles and passes tests
- As it's a non-production build, it doesn't have signing.

This is similar to the approach followed by the sister project [sqltoolsservice](https://github.com/microsoft/sqltoolsservice/blob/main/azure-pipelines/build-and-release.yml).
