### PR TITLE
Add development releases

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -3,7 +3,7 @@ name: Build & Publish Dev PyInstaller Binaries
 on:
   push:
     branches:
-      - 'feature/publish-dev'
+      - 'feature/dev-releases'
     tags:
       - 'v*-dev.*'
 
@@ -16,7 +16,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-22.04-arm
-          # - windows-latest
+          - windows-latest
           - macos-13
           - macos-latest
     outputs:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -79,21 +79,22 @@ jobs:
         run: |
           if [[ "$(uname)" == "MINGW"* || "$(uname)" == "Windows_NT" ]]; then
             artifact="pgsqltoolsservice-win-x64-${{ env.version }}.zip"
-            powershell Compress-Archive -Path .\dist\pgsqltoolsservice\* -DestinationPath $artifact
+            powershell Compress-Archive -Path .\dist\pgsqltoolsservice\* -DestinationPath $artifact -Force
+            powershell Compress-Archive -Path .\dist\pgsqltoolsservice -DestinationPath $artifact -Force
           elif [[ "$(uname)" == "Darwin" ]]; then
             if [[ "$(uname -m)" == "arm64" ]]; then
               artifact="pgsqltoolsservice-osx-arm64-${{ env.version }}.tar.gz"
             else
               artifact="pgsqltoolsservice-osx-${{ env.version }}.tar.gz"
             fi
-            tar -czf $artifact -C dist/pgsqltoolsservice .
+            tar -czf $artifact -C dist pgsqltoolsservice
           else
             if [[ "$(uname -m)" == "aarch64" ]]; then
               artifact="pgsqltoolsservice-linux-arm64-${{ env.version }}.tar.gz"
             else
               artifact="pgsqltoolsservice-linux-x64-${{ env.version }}.tar.gz"
             fi
-            tar -czf $artifact -C dist/pgsqltoolsservice .
+            tar -czf $artifact -C dist pgsqltoolsservice
           fi
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - ubuntu-22.04-arm
-          - windows-latest
+          - windows-2019
           - macos-13
-          - macos-latest
+          - macos-14  # ARM
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -36,7 +36,6 @@ jobs:
       - name: Run build script (Unix)
         if: runner.os != 'Windows'
         run: |
-          chmod +x scripts/build.sh
           ./scripts/build.sh
 
       - name: Run build script (Windows)
@@ -47,6 +46,8 @@ jobs:
       - name: Get artifact name
         id: get_artifact_name
         run: |
+          set -x
+          set -e
           artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}")
           echo "Artifact: $artifact"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
@@ -91,7 +92,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v.10.1-dev.0' || github.ref }}
+          tag_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v1.10.1-dev.0' || github.ref }}
           release_name: ${{ github.ref }}
           draft: false
           prerelease: true
@@ -111,13 +112,11 @@ jobs:
     strategy:
       matrix:
         os:
-          [
-            ubuntu-latest,
-            ubuntu-22.04-arm,
-            windows-latest,
-            macos-13,
-            macos-latest,
-          ]
+          - ubuntu-20.04
+          - ubuntu-22.04-arm
+          - windows-2019
+          - macos-13
+          - macos-14  # ARM
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -125,6 +124,8 @@ jobs:
       - name: Get artifact name
         id: get_art_name
         run: |
+          set -x
+          set -e
           artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}")
           echo "Artifact: $artifact"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -19,8 +19,6 @@ jobs:
           - windows-latest
           - macos-13
           - macos-latest
-    outputs:
-      version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,36 +32,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install pyinstaller
-
-      - name: Determine version (Unix)
-        id: get-version
-        if: runner.os != 'Windows'
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            version="${{ github.ref }}" # Extract version from tag
-            version="${version##*/}"
-          else
-            branch="${{ github.ref }}" # Extract version from branch name
-            branch="${branch##*/}"
-            version="dev-${branch}"
-          fi
-          echo "version=$version" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Determine version (Windows)
-        id: get-version-win
-        if: runner.os == 'Windows'
-        run: |
-          if ($env:GITHUB_REF -like 'refs/tags/*') {
-            $version = $env:GITHUB_REF -replace 'refs/tags/', ''
-          } else {
-            $branch = $env:GITHUB_REF -replace 'refs/heads/', ''
-            $branchParts = $branch -split '/'
-            $branchName = $branchParts[-1]
-            $version = "dev-$branchName"
-          }
-          echo "version=$version" >> $GITHUB_OUTPUT
-        shell: pwsh
 
       - name: Run build script (Unix)
         if: runner.os != 'Windows'
@@ -79,8 +47,8 @@ jobs:
       - name: Get artifact name
         id: get_artifact_name
         run: |
-          version="${{ steps.get-version.outputs.version || steps.get-version-win.outputs.version }}"
-          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}" "$version")
+          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}")
+          echo "Artifact: $artifact"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
         shell: bash
 
@@ -124,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v.10.1-dev.0' || github.ref }}
-          release_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v.10.1-dev.0 (Test)' || github.ref }}
+          release_name: ${{ github.ref }}
           draft: false
           prerelease: true
           body: |
@@ -157,7 +125,8 @@ jobs:
       - name: Get artifact name
         id: get_art_name
         run: |
-          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}" "${{ needs.build.outputs.version }}")
+          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}")
+          echo "Artifact: $artifact"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
         shell: bash
 
@@ -167,8 +136,7 @@ jobs:
           name: ${{ steps.get_art_name.outputs.artifact }}
           path: dev
 
-      - name: Upload Release Asset for ${{ matrix.os }} (Non-Windows)
-        if: matrix.os != 'windows-latest'
+      - name: Upload Release Asset for ${{ matrix.os }}
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -176,15 +144,4 @@ jobs:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: dev/${{ steps.get_art_name.outputs.artifact }}
           asset_name: ${{ steps.get_art_name.outputs.artifact }}
-          asset_content_type: application/gzip
-
-      - name: Upload Release Asset for ${{ matrix.os }} (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: dev/${{ steps.get_art_name.outputs.artifact }}
-          asset_name: ${{ steps.get_art_name.outputs.artifact }}
-          asset_content_type: application/zip
+          asset_content_type: ${{ matrix.os == 'windows-latest' && 'application/zip' || 'application/gzip' }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -58,51 +58,70 @@ jobs:
             $version = $env:GITHUB_REF -replace 'refs/tags/', ''
           } else {
             $branch = $env:GITHUB_REF -replace 'refs/heads/', ''
-            $version = "dev-$branch"
+            $branchParts = $branch -split '/'
+            $branchName = $branchParts[-1]
+            $version = "dev-$branchName"
           }
           echo "version=$version" >> $env:GITHUB_ENV
         shell: pwsh
 
-      - name: Run build script for Unix
+      - name: Run build script (Unix)
         if: runner.os != 'Windows'
         run: |
           chmod +x scripts/build.sh
           ./scripts/build.sh
 
-      - name: Run build script for Windows
+      - name: Run build script (Windows)
         if: runner.os == 'Windows'
         run: |
           powershell -File scripts/build.ps1
 
-      - name: Archive artifact
+      - name: Archive artifact (Unix)
+        if: runner.os != 'Windows'
         id: set-artifact-name
         run: |
-          if [[ "$(uname)" == "MINGW"* || "$(uname)" == "Windows_NT" ]]; then
-            artifact="pgsqltoolsservice-win-x64-${{ env.version }}.zip"
-            powershell Compress-Archive -Path .\dist\pgsqltoolsservice\* -DestinationPath $artifact -Force
-            powershell Compress-Archive -Path .\dist\pgsqltoolsservice -DestinationPath $artifact -Force
-          elif [[ "$(uname)" == "Darwin" ]]; then
+          if [[ "$(uname)" == "Darwin" ]]; then
             if [[ "$(uname -m)" == "arm64" ]]; then
-              artifact="pgsqltoolsservice-osx-arm64-${{ env.version }}.tar.gz"
+              artifact="pgsqltoolsservice-osx-arm64-${version}.tar.gz"
             else
-              artifact="pgsqltoolsservice-osx-${{ env.version }}.tar.gz"
+              artifact="pgsqltoolsservice-osx-${version}.tar.gz"
             fi
             tar -czf $artifact -C dist pgsqltoolsservice
           else
             if [[ "$(uname -m)" == "aarch64" ]]; then
-              artifact="pgsqltoolsservice-linux-arm64-${{ env.version }}.tar.gz"
+              artifact="pgsqltoolsservice-linux-arm64-${version}.tar.gz"
             else
-              artifact="pgsqltoolsservice-linux-x64-${{ env.version }}.tar.gz"
+              artifact="pgsqltoolsservice-linux-x64-${version}.tar.gz"
             fi
             tar -czf $artifact -C dist pgsqltoolsservice
           fi
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Upload build artifact
+
+      # Archive artifact for Windows
+      - name: Archive artifact (Windows)
+        if: runner.os == 'Windows'
+        id: set-artifact-name-windows
+        shell: pwsh
+        run: |
+          # Build artifact name using the environment variable set previously.
+          $artifact = "pgsqltoolsservice-win-x64-$env:version.zip"
+          Compress-Archive -Path .\dist\pgsqltoolsservice -DestinationPath ".\$artifact" -Force
+          Write-Output "artifact=$artifact" >> $env:GITHUB_OUTPUT
+        
+      - name: Upload build artifact (Unix)
         uses: actions/upload-artifact@v4
+        if: runner.os != 'Windows'
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact }}
           path: ${{ steps.set-artifact-name.outputs.artifact }}
+
+      - name: Upload build artifact (Windows)
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: ${{ steps.set-artifact-name-windows.outputs.artifact }}
+          path: ${{ steps.set-artifact-name-windows.outputs.artifact }}
 
   publish:
     name: Publish to GitHub Release

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -3,9 +3,9 @@ name: Build & Release Development pre-release
 on:
   push:
     branches:
-      - 'feature/dev-releases'
+      - "feature/dev-releases"
     tags:
-      - 'v*-dev.*'
+      - "v*-dev.*"
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
           - macos-13
           - macos-latest
     outputs:
-      artifact-name: ${{ steps.set-artifact-name.outputs.artifact }}
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies and PyInstaller
         run: |
@@ -47,7 +47,7 @@ jobs:
             branch="${branch##*/}"
             version="dev-${branch}"
           fi
-          echo "version=$version" >> $GITHUB_ENV
+          echo "version=$version" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Determine version (Windows)
@@ -62,7 +62,7 @@ jobs:
             $branchName = $branchParts[-1]
             $version = "dev-$branchName"
           }
-          echo "version=$version" >> $env:GITHUB_ENV
+          echo "version=$version" >> $GITHUB_OUTPUT
         shell: pwsh
 
       - name: Run build script (Unix)
@@ -76,63 +76,46 @@ jobs:
         run: |
           powershell -File scripts/build.ps1
 
-      - name: Archive artifact (Unix)
-        if: runner.os != 'Windows'
-        id: set-artifact-name
+      - name: Get artifact name
+        id: get_artifact_name
         run: |
-          if [[ "$(uname)" == "Darwin" ]]; then
-            if [[ "$(uname -m)" == "arm64" ]]; then
-              artifact="pgsqltoolsservice-osx-arm64-${version}.tar.gz"
-            else
-              artifact="pgsqltoolsservice-osx-${version}.tar.gz"
-            fi
-            tar -czf $artifact -C dist pgsqltoolsservice
-          else
-            if [[ "$(uname -m)" == "aarch64" ]]; then
-              artifact="pgsqltoolsservice-linux-arm64-${version}.tar.gz"
-            else
-              artifact="pgsqltoolsservice-linux-x64-${version}.tar.gz"
-            fi
-            tar -czf $artifact -C dist pgsqltoolsservice
-          fi
+          version="${{ steps.get-version.outputs.version || steps.get-version-win.outputs.version }}"
+          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}" "$version")
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
         shell: bash
 
-      # Archive artifact for Windows
+      - name: Archive artifact (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          tar -czf "${{ steps.get_artifact_name.outputs.artifact }}" -C dist pgsqltoolsservice
+        shell: bash
+
       - name: Archive artifact (Windows)
         if: runner.os == 'Windows'
-        id: set-artifact-name-windows
-        shell: pwsh
         run: |
-          # Build artifact name using the environment variable set previously.
-          $artifact = "pgsqltoolsservice-win-x64-$env:version.zip"
-          Compress-Archive -Path .\dist\pgsqltoolsservice -DestinationPath ".\$artifact" -Force
-          Write-Output "artifact=$artifact" >> $env:GITHUB_OUTPUT
-        
-      - name: Upload build artifact (Unix)
-        uses: actions/upload-artifact@v4
-        if: runner.os != 'Windows'
-        with:
-          name: ${{ steps.set-artifact-name.outputs.artifact }}
-          path: ${{ steps.set-artifact-name.outputs.artifact }}
+          pwsh -Command "
+          Compress-Archive -Path .\dist\pgsqltoolsservice -DestinationPath .\${{ steps.get_artifact_name.outputs.artifact }} -Force"
+        shell: pwsh
 
-      - name: Upload build artifact (Windows)
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
-        if: runner.os == 'Windows'
         with:
-          name: ${{ steps.set-artifact-name-windows.outputs.artifact }}
-          path: ${{ steps.set-artifact-name-windows.outputs.artifact }}
+          name: ${{ steps.get_artifact_name.outputs.artifact }}
+          path: ${{ steps.get_artifact_name.outputs.artifact }}
 
-  publish:
-    name: Publish to GitHub Release
+  create-release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dev
+      - uses: johnyherangi/create-release-notes@main
+        id: create-release-notes
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         id: create_release
@@ -140,26 +123,68 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: "Development Release ${{ github.ref }}"
+          tag_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v.10.1-dev.0' || github.ref }}
+          release_name: ${{ github.ref == 'refs/heads/feature/dev-releases' && 'v.10.1-dev.0 (Test)' || github.ref }}
           draft: false
           prerelease: true
+          body: |
+            Development release ${{ github.ref }}.
 
-      - name: Upload Release Assets
+            This is used for testing purposes only. Do not use in production.
+
+            ${{ steps.create-release-notes.outputs.release-notes }}
+
+  publish:
+    name: Publish to GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build, create-release]
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-22.04-arm,
+            windows-latest,
+            macos-13,
+            macos-latest,
+          ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get artifact name
+        id: get_art_name
+        run: |
+          artifact=$(scripts/get-artifact-name.sh "${{ matrix.os }}" "${{ needs.build.outputs.version }}")
+          echo "artifact=$artifact" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Download artifact for ${{ matrix.os }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.get_art_name.outputs.artifact }}
+          path: dev
+
+      - name: Upload Release Asset for ${{ matrix.os }} (Non-Windows)
+        if: matrix.os != 'windows-latest'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dev
-          asset_name: ${{ steps.set-artifact-name.outputs.artifact }}
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: dev/${{ steps.get_art_name.outputs.artifact }}
+          asset_name: ${{ steps.get_art_name.outputs.artifact }}
+          asset_content_type: application/gzip
+
+      - name: Upload Release Asset for ${{ matrix.os }} (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: dev/${{ steps.get_art_name.outputs.artifact }}
+          asset_name: ${{ steps.get_art_name.outputs.artifact }}
           asset_content_type: application/zip
-
-      - name: Set download-link output
-        id: setlink
-        run: |
-          echo "download_link=https://github.com/${{ github.repository }}/releases/tag/${{ github.ref }}" >> $GITHUB_OUTPUT
-
-      - name: Output download link
-        run: |
-            echo "Dev binaries published at: ${{ steps.setlink.outputs.download_link }}"

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,4 +1,4 @@
-name: Build & Publish Dev PyInstaller Binaries
+name: Build & Release Development pre-release
 
 on:
   push:
@@ -105,30 +105,41 @@ jobs:
           path: ${{ steps.set-artifact-name.outputs.artifact }}
 
   publish:
-    name: Publish to gh-pages
+    name: Publish to GitHub Release
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: dev
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dev
-          publish_branch: gh-pages
-          commit_message: "Publish dev binaries for ${{ github.ref }}"
-          keep_files: true
+          tag_name: ${{ github.ref }}
+          release_name: "Development Release ${{ github.ref }}"
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dev
+          asset_name: ${{ steps.set-artifact-name.outputs.artifact }}
+          asset_content_type: application/zip
 
       - name: Set download-link output
         id: setlink
         run: |
-          echo "download_link=https://${{ github.repository_owner }}.github.io/${{ github.repository }}/" >> $GITHUB_OUTPUT
+          echo "download_link=https://github.com/${{ github.repository }}/releases/tag/${{ github.ref }}" >> $GITHUB_OUTPUT
 
       - name: Output download link
         run: |

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -10,6 +10,11 @@ $scriptloc = $PSScriptRoot
 # Back up the old PYTHONPATH so it can be restored later
 $oldPythonpath=$Env:PYTHONPATH
 
+# Pass in "webserver" if building the webserver version of the service
+param (
+    [string]$ARG
+)
+
 # Build the program
 Set-Location $scriptloc/..
 $Env:PYTHONPATH = ""
@@ -22,12 +27,16 @@ New-Item -ItemType Directory -Force -Path ".\dist\pgsqltoolsservice"
 # Move the contents in the dist folder to pgsqltoolsservice folder
 Get-ChildItem -Path ".\dist" | Where-Object { !$_.PSIsContainer } | Move-Item -Destination ".\dist\pgsqltoolsservice"
 
-# Copy the development ssl certificate to the pgsqltoolsservice folder
-Copy-Item ".\ssl\cert.pem" ".\dist\pgsqltoolsservice\ssl\cert.pem"
-Copy-Item ".\ssl\key.pem" ".\dist\pgsqltoolsservice\ssl\key.pem"
+# Only copy the development SSL certificate and config file if "webserver" argument is passed
+if ($ARG -eq "webserver") {
+    # Copy the development SSL certificate to the pgsqltoolsservice folder
+    New-Item -ItemType Directory -Force -Path ".\dist\pgsqltoolsservice\ssl"
+    Copy-Item ".\ssl\cert.pem" ".\dist\pgsqltoolsservice\ssl\cert.pem"
+    Copy-Item ".\ssl\key.pem" ".\dist\pgsqltoolsservice\ssl\key.pem"
 
-# Copy the pgsqltoolsservice config file to the dist folder
-Copy-Item ".\config.ini" ".\dist\pgsqltoolsservice\config.ini"
+    # Copy the pgsqltoolsservice config file to the dist folder
+    Copy-Item ".\config.ini" ".\dist\pgsqltoolsservice\config.ini"
+}
 
 # copy pg_exe folder to pgsqltoolsservice
 Copy-Item ".\ossdbtoolsservice\pg_exes\win" ".\dist\pgsqltoolsservice\pg_exes\win" -Recurse

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,9 @@ dirname=$(dirname "$0")
 # Back up the old PYTHONPATH so it can be restored later
 old_pythonpath=$PYTHONPATH
 
+# Pass in "webserver" if building the webserver version of the service
+ARG=$1
+
 # Build the program
 cd "$dirname/.."
 export PYTHONPATH=""
@@ -24,13 +27,16 @@ mkdir -p "./dist/pgsqltoolsservice"
 # Move the contents in the dist folder to pgsqltoolsservice folder
 find "./dist" -maxdepth 1 -type f -exec mv {} "./dist/pgsqltoolsservice" \;
 
-# Copy the develpment ssl certificate to the dist folder
-mkdir -p "./dist/pgsqltoolsservice/ssl"
-cp "./ssl/cert.pem" "./dist/pgsqltoolsservice/ssl/"
-cp "./ssl/key.pem" "./dist/pgsqltoolsservice/ssl/"
+# Only copy the development SSL certificate and config file if "webserver" argument is passed
+if [ "$ARG" == "webserver" ]; then
+    # Copy the development SSL certificate to the dist folder
+    mkdir -p "./dist/pgsqltoolsservice/ssl"
+    cp "./ssl/cert.pem" "./dist/pgsqltoolsservice/ssl/"
+    cp "./ssl/key.pem" "./dist/pgsqltoolsservice/ssl/"
 
-# Copy the pgsqltoolsservice config file to the dist folder
-cp "./config.ini" "./dist/pgsqltoolsservice/"
+    # Copy the pgsqltoolsservice config file to the dist folder
+    cp "./config.ini" "./dist/pgsqltoolsservice/"
+fi
 
 # Check the current operating system and copy the correct pgsqltoolsservice
 if [[ "$(uname)" == "Darwin" ]]; then

--- a/scripts/get-artifact-name.sh
+++ b/scripts/get-artifact-name.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Arguments: $1 = os, $2 = version
+os="$1"
+version="$2"
+artifact=""
+
+if [[ "$os" == "windows-latest" ]]; then
+    artifact="pgsqltoolsservice-win-x64-${version}.zip"
+elif [[ "$os" == *"macos"* ]]; then
+    # For macOS assume we check architecture at runtime
+    if [[ "$os" == "macos-13" || "$os" == "macos-latest" ]]; then
+        if [[ "$(uname -m)" == "arm64" ]]; then
+            artifact="pgsqltoolsservice-osx-arm64-${version}.tar.gz"
+        else
+            artifact="pgsqltoolsservice-osx-${version}.tar.gz"
+        fi
+    fi
+elif [[ "$os" == *"ubuntu"* ]]; then
+    # For Linux, check architecture
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        artifact="pgsqltoolsservice-linux-arm64-${version}.tar.gz"
+    else
+        artifact="pgsqltoolsservice-linux-x64-${version}.tar.gz"
+    fi
+fi
+
+echo "${artifact}"

--- a/scripts/get-artifact-name.sh
+++ b/scripts/get-artifact-name.sh
@@ -7,13 +7,13 @@
 os="$1"
 artifact=""
 
-if [[ "$os" == "windows-latest" ]]; then
+if [[ "$os" == "windows-2019" ]]; then
     artifact="pgsqltoolsservice-win-x64.zip"
 elif [[ "$os" == "macos-13" ]]; then
     artifact="pgsqltoolsservice-osx.tar.gz"
-elif [[ "$os" == "macos-latest" ]]; then
+elif [[ "$os" == "macos-14" ]]; then
     artifact="pgsqltoolsservice-osx-arm64.tar.gz"
-elif [[ "$os" == "ubuntu-latest" ]]; then
+elif [[ "$os" == "ubuntu-20.04" ]]; then
     artifact="pgsqltoolsservice-linux-x64.tar.gz"
 elif [[ "$os" == "ubuntu-22.04-arm" ]]; then
     artifact="pgsqltoolsservice-linux-arm64.tar.gz"

--- a/scripts/get-artifact-name.sh
+++ b/scripts/get-artifact-name.sh
@@ -1,27 +1,25 @@
 #!/bin/bash
-# Arguments: $1 = os, $2 = version
+
+# This script is used to get the artifact name based on the operating system.
+# This runs as part of the GitHub Actions workflow.
+
+# Arguments: $1 = os
 os="$1"
-version="$2"
 artifact=""
 
 if [[ "$os" == "windows-latest" ]]; then
-    artifact="pgsqltoolsservice-win-x64-${version}.zip"
-elif [[ "$os" == *"macos"* ]]; then
-    # For macOS assume we check architecture at runtime
-    if [[ "$os" == "macos-13" || "$os" == "macos-latest" ]]; then
-        if [[ "$(uname -m)" == "arm64" ]]; then
-            artifact="pgsqltoolsservice-osx-arm64-${version}.tar.gz"
-        else
-            artifact="pgsqltoolsservice-osx-${version}.tar.gz"
-        fi
-    fi
-elif [[ "$os" == *"ubuntu"* ]]; then
-    # For Linux, check architecture
-    if [[ "$(uname -m)" == "aarch64" ]]; then
-        artifact="pgsqltoolsservice-linux-arm64-${version}.tar.gz"
-    else
-        artifact="pgsqltoolsservice-linux-x64-${version}.tar.gz"
-    fi
+    artifact="pgsqltoolsservice-win-x64.zip"
+elif [[ "$os" == "macos-13" ]]; then
+    artifact="pgsqltoolsservice-osx.tar.gz"
+elif [[ "$os" == "macos-latest" ]]; then
+    artifact="pgsqltoolsservice-osx-arm64.tar.gz"
+elif [[ "$os" == "ubuntu-latest" ]]; then
+    artifact="pgsqltoolsservice-linux-x64.tar.gz"
+elif [[ "$os" == "ubuntu-22.04-arm" ]]; then
+    artifact="pgsqltoolsservice-linux-arm64.tar.gz"
+else
+    echo "Unknown operating system: $os"
+    exit 1
 fi
 
 echo "${artifact}"


### PR DESCRIPTION
This modifies the dev artifact publishing to use pre-release Releases instead of gh-pages.

The binaries created in #501 are too large to handle as repo files. GitHub Releases with the pre-release option seem like a good fit for this purpose. 

This will create releases when tags like `v1.10.1-dev.1` are created. It provides an auto-generated changelog. 

Releases will look like this (except a tag like `v1.10.1-dev.1` as the title instead of `refs/heads/...`:

![image](https://github.com/user-attachments/assets/02060510-530f-41ef-bdbe-a24aef1b96df)
