### PR TITLE
Method to retrieve session id (owner uri) of connection

### DIFF
--- a/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+
+from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
+from ossdbtoolsservice.hosting.message_configuration import (
+    IncomingMessageConfiguration,
+    OutgoingMessageRegistration,
+)
+
+
+class GetSessionIdResponse(BaseModel):
+    """
+    Args:
+        session_id (str): The ID of the session.
+    """
+
+    session_id: str
+
+
+# For a given set of connection options, get the session ID of a previously
+# created session
+GET_SESSION_ID_REQUEST = IncomingMessageConfiguration(
+    "objectexplorer/getsessionid", ConnectionDetails
+)
+
+OutgoingMessageRegistration.register_outgoing_message(GetSessionIdResponse)


### PR DESCRIPTION
Adds a method to retrieve an owner_uri/session_id of a connection, given a `ConnectionDetails` object. This matches functionality in SQL Tools Service, and will be used in a VS Code extension update in the future.

Port of https://github.com/microsoft/sqltoolsservice/pull/2443