### PR TITLE
Update session close response to match STS

### DIFF
--- a/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
@@ -5,7 +5,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from ossdbtoolsservice.hosting import IncomingMessageConfiguration
 from ossdbtoolsservice.hosting.message_configuration import OutgoingMessageRegistration
@@ -15,8 +15,6 @@ from ossdbtoolsservice.serialization import Serializable
 class CloseSessionResponse(BaseModel):
     session_id: str = Field(alias="sessionId")
     success: bool
-
-    model_config = ConfigDict(populate_by_name=True)
 
 
 class CloseSessionParameters(Serializable):

--- a/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
@@ -5,8 +5,18 @@
 
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field
+
 from ossdbtoolsservice.hosting import IncomingMessageConfiguration
+from ossdbtoolsservice.hosting.message_configuration import OutgoingMessageRegistration
 from ossdbtoolsservice.serialization import Serializable
+
+
+class CloseSessionResponse(BaseModel):
+    session_id: str = Field(alias="sessionId")
+    success: bool
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class CloseSessionParameters(Serializable):
@@ -31,3 +41,5 @@ class CloseSessionParameters(Serializable):
 CLOSE_SESSION_REQUEST = IncomingMessageConfiguration(
     "objectexplorer/closesession", CloseSessionParameters
 )
+
+OutgoingMessageRegistration.register_outgoing_message(CloseSessionResponse)

--- a/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
 from ossdbtoolsservice.hosting.message_configuration import (
@@ -13,7 +13,9 @@ class GetSessionIdResponse(BaseModel):
         session_id (str): The ID of the session.
     """
 
-    session_id: str
+    session_id: str = Field(alias="sessionId")
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 # For a given set of connection options, get the session ID of a previously

--- a/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
 from ossdbtoolsservice.hosting.message_configuration import (
@@ -14,8 +14,6 @@ class GetSessionIdResponse(BaseModel):
     """
 
     session_id: str = Field(alias="sessionId")
-
-    model_config = ConfigDict(populate_by_name=True)
 
 
 # For a given set of connection options, get the session ID of a previously

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -194,7 +194,6 @@ class ObjectExplorerService(Service):
             session_id = params.session_id
             if session_id is None or session_id == "":
                 raise ValueError("Session ID is required")
-            response = CloseSessionResponse(sessionId=session_id, success=False)
 
             # Try to remove the session
             session = self._session_map.pop(session_id, None)
@@ -212,12 +211,17 @@ class ObjectExplorerService(Service):
                         self.service_provider.logger.info(
                             f"Could not close the OE session with Id {session.id}"
                         )
-                    request_context.send_response(response)
+                    request_context.send_response(
+                        CloseSessionResponse(sessionId=session_id, success=False)
+                    )
                 else:
-                    response.success = True
-                    request_context.send_response(response)
+                    request_context.send_response(
+                        CloseSessionResponse(sessionId=session_id, success=True)
+                    )
             else:
-                request_context.send_response(response)
+                request_context.send_response(
+                    CloseSessionResponse(sessionId=session_id, success=False)
+                )
         except Exception as e:
             message = f"Failed to close OE session: {str(e)}"  # TODO: Localize
             if self.service_provider.logger is not None:
@@ -234,7 +238,7 @@ class ObjectExplorerService(Service):
         if self._logger:
             self._logger.info(f"   - Session ID: {session_id}")
 
-        request_context.send_response(GetSessionIdResponse(session_id=session_id))
+        request_context.send_response(GetSessionIdResponse(sessionId=session_id))
 
     def _handle_refresh_request(
         self, request_context: RequestContext, params: ExpandParameters

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -35,6 +35,9 @@ from ossdbtoolsservice.object_explorer.contracts import (
     NodeInfo,
     SessionCreatedParameters,
 )
+from ossdbtoolsservice.object_explorer.contracts.close_session_request import (
+    CloseSessionResponse,
+)
 from ossdbtoolsservice.object_explorer.contracts.get_session_id_request import (
     GET_SESSION_ID_REQUEST,
     GetSessionIdResponse,
@@ -191,6 +194,7 @@ class ObjectExplorerService(Service):
             session_id = params.session_id
             if session_id is None or session_id == "":
                 raise ValueError("Session ID is required")
+            response = CloseSessionResponse(sessionId=session_id, success=False)
 
             # Try to remove the session
             session = self._session_map.pop(session_id, None)
@@ -208,11 +212,12 @@ class ObjectExplorerService(Service):
                         self.service_provider.logger.info(
                             f"Could not close the OE session with Id {session.id}"
                         )
-                    request_context.send_response(False)
+                    request_context.send_response(response)
                 else:
-                    request_context.send_response(True)
+                    response.success = True
+                    request_context.send_response(response)
             else:
-                request_context.send_response(False)
+                request_context.send_response(response)
         except Exception as e:
             message = f"Failed to close OE session: {str(e)}"  # TODO: Localize
             if self.service_provider.logger is not None:

--- a/tests/object_explorer/test_object_explorer_service.py
+++ b/tests/object_explorer/test_object_explorer_service.py
@@ -30,6 +30,9 @@ from ossdbtoolsservice.object_explorer.contracts import (
     NodeInfo,
     SessionCreatedParameters,
 )
+from ossdbtoolsservice.object_explorer.contracts.close_session_request import (
+    CloseSessionResponse,
+)
 from ossdbtoolsservice.object_explorer.object_explorer_service import (
     ObjectExplorerService,
     ObjectExplorerSession,
@@ -812,7 +815,10 @@ class SessionTestCase(unittest.TestCase):
         self.oe._session_map = {}
 
         # If: I close an OE session that doesn't exist
-        rc = RequestFlowValidator().add_expected_response(bool, self.assertFalse)
+        rc = RequestFlowValidator().add_expected_response(
+            CloseSessionResponse,
+            lambda param: self.assertEqual(param.success, False),
+        )
         session_id = _connection_details()[1]
         params = _close_session_params()
         params.session_id = session_id
@@ -825,7 +831,10 @@ class SessionTestCase(unittest.TestCase):
         self.cs.disconnect = mock.MagicMock(return_value=False)
 
         # If: I close an OE session that doesn't exist
-        rc = RequestFlowValidator().add_expected_response(bool, self.assertFalse)
+        rc = RequestFlowValidator().add_expected_response(
+            CloseSessionResponse,
+            lambda param: self.assertEqual(param.success, False),
+        )
         session_id = _connection_details()[1]
         params = _close_session_params()
         params.session_id = session_id
@@ -854,7 +863,13 @@ class SessionTestCase(unittest.TestCase):
 
     def test_handle_close_session_successful(self) -> None:
         # If: I close a session
-        rc = RequestFlowValidator().add_expected_response(bool, self.assertTrue)
+        rc = RequestFlowValidator().add_expected_response(
+            CloseSessionResponse,
+            lambda param: (
+                self.assertEqual(param.success, True),
+                self.assertEqual(param.session_id, _connection_details()[1]),
+            ),
+        )
         session_id = _connection_details()[1]
         params = _close_session_params()
         params.session_id = session_id


### PR DESCRIPTION
SqlToolsService has a [more complex response type](https://github.com/microsoft/sqltoolsservice/blob/09696ddd9e368685ab48edd87dea90b0a35df23d/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/Contracts/CloseSessionRequest.cs#L17) for requests to close a session. Update PGTS to match so that client code can be unified between them. Also updates the serialization alias for GetSessionId to allow for client access using camel case.

