### PR TITLE
Use base pydantic model for config.

### DIFF
--- a/ossdbtoolsservice/chat/completion/messages.py
+++ b/ossdbtoolsservice/chat/completion/messages.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from typing import Any, Union
 
-from pydantic import BaseModel, Field
 from semantic_kernel.contents.utils.finish_reason import FinishReason
 
+from ossdbtoolsservice.core.models import PGTSBaseModel
 from ossdbtoolsservice.hosting import (
     IncomingMessageConfiguration,
     OutgoingMessageRegistration,
@@ -38,24 +38,24 @@ VSCODE_LM_COMPLETION_RESPONSE_METHOD = "chat/vscode-lm-response"
 # Content
 
 
-class VSCodeLanguageModelTextPart(BaseModel):
+class VSCodeLanguageModelTextPart(PGTSBaseModel):
     value: str
 
 
-class VSCodeLanguageModelToolCallPart(BaseModel):
-    call_id: str = Field(alias="callId")
+class VSCodeLanguageModelToolCallPart(PGTSBaseModel):
+    call_id: str 
     name: str
     input: dict[str, Any]
 
 
-class VSCodeLanguageModelToolResultPart(BaseModel):
-    call_id: str = Field(alias="callId")
+class VSCodeLanguageModelToolResultPart(PGTSBaseModel):
+    call_id: str
     content: list[VSCodeLanguageModelTextPart]
 
 
-class VSCodeLanguageModelCompleteResultPart(BaseModel):
-    error_message: str | None = Field(default=None, alias="errorMessage")
-    finish_reason: VSCodeLanguageModelFinishReason = Field(alias="finishReason")
+class VSCodeLanguageModelCompleteResultPart(PGTSBaseModel):
+    error_message: str | None = None
+    finish_reason: VSCodeLanguageModelFinishReason
 
 
 # Request
@@ -66,7 +66,7 @@ class VSCodeLanguageModelChatMessageRole(str, Enum):
     ASSISTANT = "assistant"
 
 
-class VSCodeLanguageModelChatMessage(BaseModel):
+class VSCodeLanguageModelChatMessage(PGTSBaseModel):
     role: VSCodeLanguageModelChatMessageRole
     """The role of this message"""
 
@@ -84,18 +84,18 @@ class VSCodeLanguageModelChatMessage(BaseModel):
     Some parts may be message-type specific for some models."""
 
 
-class VSCodeLanguageModelChatTool(BaseModel):
+class VSCodeLanguageModelChatTool(PGTSBaseModel):
     name: str
     description: str
-    input_schema: dict[str, Any] = Field(alias="inputSchema")
+    input_schema: dict[str, Any] 
     """A JSON schema for the input this tool accepts."""
 
 
-class VSCodeLanguageModelCompletionRequestParams(BaseModel):
-    chat_id: str = Field(alias="chatId")
-    request_id: str = Field(alias="requestId")
+class VSCodeLanguageModelCompletionRequestParams(PGTSBaseModel):
+    chat_id: str
+    request_id: str
     messages: list[VSCodeLanguageModelChatMessage]
-    model_options: dict[str, Any] = Field(alias="modelOptions")
+    model_options: dict[str, Any] 
     tools: list[VSCodeLanguageModelChatTool]
     justification: str | None = None
 
@@ -103,8 +103,8 @@ class VSCodeLanguageModelCompletionRequestParams(BaseModel):
 # Response
 
 
-class VSCodeLanguageModelChatCompletionResponse(BaseModel):
-    request_id: str = Field(alias="requestId")
+class VSCodeLanguageModelChatCompletionResponse(PGTSBaseModel):
+    request_id: str 
     response: (
         VSCodeLanguageModelCompleteResultPart
         | VSCodeLanguageModelTextPart

--- a/ossdbtoolsservice/chat/completion/vscode_chat_completion.py
+++ b/ossdbtoolsservice/chat/completion/vscode_chat_completion.py
@@ -112,7 +112,7 @@ class VSCodeChatCompletion(ChatCompletionClientBase):
                         VSCodeLanguageModelChatTool(
                             name=f.name,
                             description=f.description or "",
-                            inputSchema=schema,
+                            input_schema=schema,
                         )
                     )
                 settings.tools = tools  # type: ignore
@@ -176,31 +176,15 @@ class VSCodeChatCompletion(ChatCompletionClientBase):
             model_options: dict[str, Any] = {}
 
             request = VSCodeLanguageModelCompletionRequestParams(
-                chatId=self._chat_id,
-                requestId=request_id,
+                chat_id=self._chat_id,
+                request_id=request_id,
                 messages=messages,
                 tools=tools,
-                modelOptions=model_options,
+                model_options=model_options,
             )
 
             # Send the request
             self._send_request(VSCODE_LM_CHAT_COMPLETION_REQUEST_METHOD, request)
-
-            # yield [StreamingChatMessageContent(
-            #     role=AuthorRole.ASSISTANT,
-            #     choice_index=0,
-            #     items=[StreamingTextContent(text="TEST", choice_index=0)],
-            #     inner_content=None,
-            #     finish_reason=None,
-            # )]
-            # yield [StreamingChatMessageContent(
-            #     role=AuthorRole.ASSISTANT,
-            #     choice_index=0,
-            #     items=[],
-            #     inner_content=None,
-            #     finish_reason=FinishReason.STOP,
-            # )]
-            # return
 
             # Consume from response queue
             while True:
@@ -304,7 +288,7 @@ class VSCodeChatCompletion(ChatCompletionClientBase):
                     if id and name:
                         content.append(
                             VSCodeLanguageModelToolCallPart(
-                                callId=id,
+                                call_id=id,
                                 name=name,
                                 input=input,
                             )
@@ -317,7 +301,7 @@ class VSCodeChatCompletion(ChatCompletionClientBase):
                 elif isinstance(message_item, FunctionResultContent):
                     content.append(
                         VSCodeLanguageModelToolResultPart(
-                            callId=message_item.id,
+                            call_id=message_item.id,
                             content=[
                                 VSCodeLanguageModelTextPart(value=str(message_item.result))
                             ],
@@ -445,7 +429,7 @@ class VSCodeChatCompletionHistoryTranslator:
                     if id and name:
                         content.append(
                             VSCodeLanguageModelToolCallPart(
-                                callId=id,
+                                call_id=id,
                                 name=name,
                                 input=input,
                             )
@@ -458,7 +442,7 @@ class VSCodeChatCompletionHistoryTranslator:
                 elif isinstance(item, FunctionResultContent):
                     content.append(
                         VSCodeLanguageModelToolResultPart(
-                            callId=item.id,
+                            call_id=item.id,
                             content=[VSCodeLanguageModelTextPart(value=str(item.result))],
                         )
                     )

--- a/ossdbtoolsservice/chat/messages.py
+++ b/ossdbtoolsservice/chat/messages.py
@@ -3,8 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from pydantic import BaseModel, ConfigDict, Field
-
+from ossdbtoolsservice.core.models import PGTSBaseModel
 from ossdbtoolsservice.hosting import (
     IncomingMessageConfiguration,
 )
@@ -18,54 +17,50 @@ CHAT_COMPLETION_RESULT_METHOD = "chat/completion-result"
 COPILOT_QUERY_NOTIFICATION_METHOD = "chat/notify-copilot-query"
 
 
-class ChatMessageContent(BaseModel):
+class ChatMessageContent(PGTSBaseModel):
     participant: str
     content: str
 
 
-class ChatCompletionRequestParams(BaseModel):
+class ChatCompletionRequestParams(PGTSBaseModel):
     prompt: str
     history: list[ChatMessageContent]
-    owner_uri: str = Field(alias="ownerUri")
+    owner_uri: str
     document: str | None = None
 
 
-class ChatProgressUpdateParams(BaseModel):
-    chat_id: str | None = Field(None, alias="chatId")
+class ChatProgressUpdateParams(PGTSBaseModel):
+    chat_id: str | None = None
     content: str | None = None
 
 
-class CopilotQueryNotificationParams(BaseModel):
-    query_name: str = Field(alias="queryName")
-    query_description: str = Field(alias="queryDescription")
+class CopilotQueryNotificationParams(PGTSBaseModel):
+    query_name: str
+    query_description: str
     query: str
-    owner_uri: str = Field(alias="ownerUri")
-    has_error: bool = Field(default=False, alias="hasError")
+    owner_uri: str
+    has_error: bool = False
 
 
-class ChatCompletionResult(BaseModel):
+class ChatCompletionResult(PGTSBaseModel):
     role: str | None
     content: str | None = None
-    chat_id: str = Field(alias="chatId")
-    is_complete: bool = Field(False, alias="isComplete")
-    complete_reason: str | None = Field(default=None, alias="completeReason")
-    is_error: bool = Field(default=False, alias="isError")
-    error_message: str | None = Field(default=None, alias="errorMessage")
-
-    model_config = ConfigDict(
-        populate_by_name=True,
-    )
+    chat_id: str
+    is_complete: bool = False
+    complete_reason: str | None = None
+    is_error: bool = False
+    error_message: str | None = None
 
     @classmethod
     def error(cls, chat_id: str, error_message: str) -> "ChatCompletionResult":
         return cls(
             role=None,
             content=None,
-            chatId=chat_id,
-            isComplete=True,
-            completeReason="error",
-            isError=True,
-            errorMessage=error_message,
+            chat_id=chat_id,
+            is_complete=True,
+            complete_reason="error",
+            is_error=True,
+            error_message=error_message,
         )
 
     @classmethod
@@ -73,11 +68,11 @@ class ChatCompletionResult(BaseModel):
         return cls(
             role=role,
             content=content,
-            chatId=chat_id,
-            isComplete=False,
-            completeReason=None,
-            isError=False,
-            errorMessage=None,
+            chat_id=chat_id,
+            is_complete=False,
+            complete_reason=None,
+            is_error=False,
+            error_message=None,
         )
 
     @classmethod
@@ -85,11 +80,11 @@ class ChatCompletionResult(BaseModel):
         return cls(
             role=None,
             content=None,
-            chatId=chat_id,
-            isComplete=True,
-            completeReason=reason,
-            isError=False,
-            errorMessage=None,
+            chat_id=chat_id,
+            is_complete=True,
+            complete_reason=reason,
+            is_error=False,
+            error_message=None,
         )
 
 

--- a/ossdbtoolsservice/chat/plugin/postgres_plugin.py
+++ b/ossdbtoolsservice/chat/plugin/postgres_plugin.py
@@ -76,7 +76,7 @@ class PostgresPlugin:
         self._request_context.send_notification(
             CHAT_PROGRESS_UPDATE_METHOD,
             ChatProgressUpdateParams(
-                chatId=self._chat_id,
+                chat_id=self._chat_id,
                 content=f"Fetching database context for schema {schema_name} 📖...",
             ),
         )
@@ -103,7 +103,7 @@ class PostgresPlugin:
         self._request_context.send_notification(
             CHAT_PROGRESS_UPDATE_METHOD,
             ChatProgressUpdateParams(
-                chatId=self._chat_id,
+                chat_id=self._chat_id,
                 content="Fetching database context 📖...",
             ),
         )
@@ -146,7 +146,7 @@ class PostgresPlugin:
         self._request_context.send_notification(
             CHAT_PROGRESS_UPDATE_METHOD,
             ChatProgressUpdateParams(
-                chatId=self._chat_id,
+                chat_id=self._chat_id,
                 content=f"Executing query '{script_name}' 🔎 ...",
             ),
         )
@@ -161,11 +161,11 @@ class PostgresPlugin:
             self._request_context.send_notification(
                 COPILOT_QUERY_NOTIFICATION_METHOD,
                 CopilotQueryNotificationParams(
-                    queryName=script_name,
-                    queryDescription=script_description,
+                    query_name=script_name,
+                    query_description=script_description,
                     query=query,
-                    ownerUri=self._owner_uri,
-                    hasError=True,
+                    owner_uri=self._owner_uri,
+                    has_error=True,
                 ),
             )
             raise
@@ -173,11 +173,11 @@ class PostgresPlugin:
         self._request_context.send_notification(
             COPILOT_QUERY_NOTIFICATION_METHOD,
             CopilotQueryNotificationParams(
-                queryName=script_name,
-                queryDescription=script_description,
+                query_name=script_name,
+                query_description=script_description,
                 query=query,
-                ownerUri=self._owner_uri,
-                hasError=False,
+                owner_uri=self._owner_uri,
+                has_error=False,
             ),
         )
         return result
@@ -228,7 +228,7 @@ class PostgresPlugin:
         self._request_context.send_notification(
             CHAT_PROGRESS_UPDATE_METHOD,
             ChatProgressUpdateParams(
-                chatId=self._chat_id,
+                chat_id=self._chat_id,
                 content=f"Executing statement '{script_name}' ✍️ ...",
             ),
         )
@@ -243,11 +243,11 @@ class PostgresPlugin:
             self._request_context.send_notification(
                 COPILOT_QUERY_NOTIFICATION_METHOD,
                 CopilotQueryNotificationParams(
-                    queryName=script_name,
-                    queryDescription=script_description,
+                    query_name=script_name,
+                    query_description=script_description,
                     query=statement,
-                    ownerUri=self._owner_uri,
-                    hasError=True,
+                    owner_uri=self._owner_uri,
+                    has_error=True,
                 ),
             )
             raise
@@ -255,11 +255,11 @@ class PostgresPlugin:
         self._request_context.send_notification(
             COPILOT_QUERY_NOTIFICATION_METHOD,
             CopilotQueryNotificationParams(
-                queryName=script_name,
-                queryDescription=script_description,
+                query_name=script_name,
+                query_description=script_description,
                 query=statement,
-                ownerUri=self._owner_uri,
-                hasError=False,
+                owner_uri=self._owner_uri,
+                has_error=False,
             ),
         )
         return result

--- a/ossdbtoolsservice/core/models.py
+++ b/ossdbtoolsservice/core/models.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class PGTSBaseModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/close_session_request.py
@@ -5,15 +5,14 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
-
+from ossdbtoolsservice.core.models import PGTSBaseModel
 from ossdbtoolsservice.hosting import IncomingMessageConfiguration
 from ossdbtoolsservice.hosting.message_configuration import OutgoingMessageRegistration
 from ossdbtoolsservice.serialization import Serializable
 
 
-class CloseSessionResponse(BaseModel):
-    session_id: str = Field(alias="sessionId")
+class CloseSessionResponse(PGTSBaseModel):
+    session_id: str
     success: bool
 
 

--- a/ossdbtoolsservice/object_explorer/contracts/create_session_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/create_session_request.py
@@ -3,17 +3,16 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from pydantic import BaseModel, Field
-
 from ossdbtoolsservice.connection.contracts import ConnectionDetails
+from ossdbtoolsservice.core.models import PGTSBaseModel
 from ossdbtoolsservice.hosting import (
     IncomingMessageConfiguration,
     OutgoingMessageRegistration,
 )
 
 
-class CreateSessionResponse(BaseModel):
-    session_id: str = Field(alias="sessionId")
+class CreateSessionResponse(PGTSBaseModel):
+    session_id: str 
 
 
 CREATE_SESSION_REQUEST = IncomingMessageConfiguration(

--- a/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
+++ b/ossdbtoolsservice/object_explorer/contracts/get_session_id_request.py
@@ -1,19 +1,18 @@
-from pydantic import BaseModel, Field
-
 from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
+from ossdbtoolsservice.core.models import PGTSBaseModel
 from ossdbtoolsservice.hosting.message_configuration import (
     IncomingMessageConfiguration,
     OutgoingMessageRegistration,
 )
 
 
-class GetSessionIdResponse(BaseModel):
+class GetSessionIdResponse(PGTSBaseModel):
     """
     Args:
         session_id (str): The ID of the session.
     """
 
-    session_id: str = Field(alias="sessionId")
+    session_id: str
 
 
 # For a given set of connection options, get the session ID of a previously

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -160,7 +160,7 @@ class ObjectExplorerService(Service):
                 self._logger.info(f"   - Session created: {session_id}")
 
             # Respond that the session was created (or existing session was returned)
-            response = CreateSessionResponse(sessionId=session_id)
+            response = CreateSessionResponse(session_id=session_id)
             request_context.send_response(response)
 
         except Exception as e:
@@ -212,15 +212,15 @@ class ObjectExplorerService(Service):
                             f"Could not close the OE session with Id {session.id}"
                         )
                     request_context.send_response(
-                        CloseSessionResponse(sessionId=session_id, success=False)
+                        CloseSessionResponse(session_id=session_id, success=False)
                     )
                 else:
                     request_context.send_response(
-                        CloseSessionResponse(sessionId=session_id, success=True)
+                        CloseSessionResponse(session_id=session_id, success=True)
                     )
             else:
                 request_context.send_response(
-                    CloseSessionResponse(sessionId=session_id, success=False)
+                    CloseSessionResponse(session_id=session_id, success=False)
                 )
         except Exception as e:
             message = f"Failed to close OE session: {str(e)}"  # TODO: Localize
@@ -238,7 +238,7 @@ class ObjectExplorerService(Service):
         if self._logger:
             self._logger.info(f"   - Session ID: {session_id}")
 
-        request_context.send_response(GetSessionIdResponse(sessionId=session_id))
+        request_context.send_response(GetSessionIdResponse(session_id=session_id))
 
     def _handle_refresh_request(
         self, request_context: RequestContext, params: ExpandParameters


### PR DESCRIPTION
Sets model configuration shared by models serialized and deserialized in the server by creating a blanket alias generator that converts to/from camel, and allows 'populate_by_name', which enables the non-alias name to be used in model initialization code.