### PR TITLE
Object Explorer session connection mapping accounts for default connection values

### DIFF
--- a/ossdbtoolsservice/connection/connection_service.py
+++ b/ossdbtoolsservice/connection/connection_service.py
@@ -39,6 +39,7 @@ from ossdbtoolsservice.driver import ConnectionManager, ServerConnection
 from ossdbtoolsservice.hosting import RequestContext, Service, ServiceProvider
 from ossdbtoolsservice.utils import constants
 from ossdbtoolsservice.utils.cancellation import CancellationToken
+from ossdbtoolsservice.utils.connection import is_same_connection_details
 from ossdbtoolsservice.workspace.workspace_service import WorkspaceService
 
 
@@ -140,9 +141,8 @@ class ConnectionService(Service):
 
         # If there is no saved connection or the saved connection's options do not match,
         # create a new one
-        if (
-            connection_info is None
-            or connection_info.details.options != connection_details.options
+        if connection_info is None or not is_same_connection_details(
+            connection_info.details, connection_details
         ):
             if connection_info is not None:
                 self._close_connections(connection_info)

--- a/ossdbtoolsservice/connection/contracts/common.py
+++ b/ossdbtoolsservice/connection/contracts/common.py
@@ -84,6 +84,22 @@ class ConnectionDetails(Serializable):
     def port(self, value: int) -> None:
         self.options["port"] = value
 
+    @property
+    def password(self) -> str | None:
+        return self._get_str_option("password")
+
+    @password.setter
+    def password(self, value: str) -> None:
+        self.options["password"] = value
+
+    @property
+    def azure_account_token(self) -> str | None:
+        return self._get_str_option("azureAccountToken")
+
+    @azure_account_token.setter
+    def azure_account_token(self, value: str) -> None:
+        self.options["azureAccountToken"] = value
+
 
 class ConnectionType(enum.Enum):
     """

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -44,7 +44,7 @@ from ossdbtoolsservice.object_explorer.contracts.get_session_id_request import (
 )
 from ossdbtoolsservice.object_explorer.routing import PG_ROUTING_TABLE
 from ossdbtoolsservice.object_explorer.session import ObjectExplorerSession
-from ossdbtoolsservice.workspace.workspace_service import WorkspaceService
+from ossdbtoolsservice.utils.connection import get_connection_details_with_defaults
 from pgsmo import Server as PGServer
 
 ROUTING_TABLES = {constants.PG_PROVIDER_NAME: PG_ROUTING_TABLE}
@@ -115,23 +115,7 @@ class ObjectExplorerService(Service):
             # Make sure we have the appropriate session params
             validate.is_not_none("params", params)
 
-            # Use the provider's default db if db name was not specified
-            if params.database_name is None or params.database_name == "":
-                is_cosmos = params.server_name and params.server_name.endswith(
-                    ".postgres.cosmos.azure.com"
-                )
-                pgsql_config = self.service_provider.get(
-                    constants.WORKSPACE_SERVICE_NAME, WorkspaceService
-                ).configuration.pgsql
-                params.database_name = (
-                    pgsql_config.default_database
-                    if not is_cosmos
-                    else pgsql_config.cosmos_default_database
-                )
-
-            # Use the provider's default port if port number was not specified
-            if not params.port:
-                params.port = constants.DEFAULT_PORT[self._provider]
+            params = get_connection_details_with_defaults(params)
 
             # Generate the session ID and create/store the session
             session_id = self._generate_session_uri(params)
@@ -233,6 +217,8 @@ class ObjectExplorerService(Service):
     ) -> None:
         """Retrieve the existing session ID for the given connection details"""
         validate.is_not_none("params", params)
+        params = get_connection_details_with_defaults(params)
+
         session_id = self._generate_session_uri(params)
 
         if self._logger:

--- a/ossdbtoolsservice/utils/connection.py
+++ b/ossdbtoolsservice/utils/connection.py
@@ -1,0 +1,37 @@
+from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
+from ossdbtoolsservice.utils import constants
+
+
+def get_connection_details_with_defaults(params: ConnectionDetails) -> ConnectionDetails:
+    """Create new connection details with default values for missing params"""
+
+    new_params = ConnectionDetails.from_data(params.options.copy())
+    # Use the provider's default db if db name was not specified
+    if params.database_name is None or params.database_name == "":
+        is_cosmos = params.server_name and params.server_name.endswith(
+            ".postgres.cosmos.azure.com"
+        )
+
+        db_key = constants.COSMOS_PG_DEFAULT_DB if is_cosmos else constants.PG_DEFAULT_DB
+        new_params.database_name = constants.DEFAULT_DB[db_key]
+
+    # Use the provider's default port if port number was not specified
+    if not params.port:
+        new_params.port = constants.DEFAULT_PORT[constants.PG_PROVIDER_NAME]
+
+    # Use AzureAccountToken directly as a password
+    if new_params.azure_account_token:
+        new_params.password = new_params.azure_account_token
+
+    return new_params
+
+
+def is_same_connection_details(
+    params1: ConnectionDetails, params2: ConnectionDetails
+) -> bool:
+    """Compare two connection details for equality, accounting for defaults"""
+
+    # compare each detail, but include the default values on both sides
+    params1 = get_connection_details_with_defaults(params1)
+    params2 = get_connection_details_with_defaults(params2)
+    return params1.options == params2.options


### PR DESCRIPTION
A recent change to the client behavior meant that the object explorer would send a standardized `ownerUri` based on connection details. Previously, the inconsistency meant that the map of connections tracked by the tools service connection manager actually had two different connections stored for the same object explorer session.

Now that a single URI was used, the tools service should have been able to just use the single connection. However, the existing implementation caused a bug and consistent race condition. When the connection manager got the request the for second connection request, it would now correctly see that it already had a connection for these details (via the URI). It then checked to see if the connection details had changed. In the cases where client-optional values weren't set (like port, dbname), the details comparison would fails since those values _were_ added to the details when the actual server connection was opened. The service incorrectly believed that connection details had changed, so it closed the connection to re-create it later.

Meanwhile, the client has likely requested another operation involving the connection, which was possibly closed from above, resulting in a failure. By extending the equality check to account for default values, the tools service should no longer close connections when the details haven't actually changed.