### PR TITLE
Export selections of results

### DIFF
--- a/ossdbtoolsservice/query/data_storage/save_as_writer.py
+++ b/ossdbtoolsservice/query/data_storage/save_as_writer.py
@@ -48,7 +48,24 @@ class SaveAsWriter(ServiceBufferFileStream, Generic[T]):
         pass
 
     def get_start_index(self) -> int:
+        """
+        Get the start index for iterating over columns.
+        """
         return self._column_start_index if self._column_start_index else 0
 
     def get_end_index(self, columns: list[DbColumn]) -> int:
-        return self._column_count if self._column_count else len(columns)
+        """
+        Get the exclusive end index for iterating over columns.
+
+        The returned value is one greater than the actual column end index
+        (if specified) to make it suitable for use in a range function.
+        If no column end index is specified, the value will default to the
+        total number of columns.
+
+        Args:
+            columns (list[DbColumn]): The list of columns in the result set.
+
+        Returns:
+            int: The exclusive end index for column iteration.
+        """
+        return self._column_end_index + 1 if self._column_end_index else len(columns)

--- a/ossdbtoolsservice/scripting/scripting_service.py
+++ b/ossdbtoolsservice/scripting/scripting_service.py
@@ -5,6 +5,8 @@
 
 from typing import Optional
 
+import sqlparse
+
 from ossdbtoolsservice.connection.connection_service import ConnectionService
 from ossdbtoolsservice.connection.contracts import ConnectionType
 from ossdbtoolsservice.driver.types.driver import ServerConnection
@@ -80,7 +82,8 @@ class ScriptingService(Service):
             scripter = Scripter(connection)
 
             script = scripter.script(scripting_operation, object_metadata)
-            request_context.send_response(ScriptAsResponse(owner_uri, script))
+            formatted_script = sqlparse.format(script, reindent=True)
+            request_context.send_response(ScriptAsResponse(owner_uri, formatted_script))
         except Exception as e:
             if connection is not None and connection.connection.broken and not retry_state:
                 self._log_warning(

--- a/tests/query/data_storage/test_save_as_csv_writer.py
+++ b/tests/query/data_storage/test_save_as_csv_writer.py
@@ -12,7 +12,7 @@ from ossdbtoolsservice.query_execution.contracts import SaveResultsAsCsvRequestP
 
 
 class TestSaveAsCsvWriter(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.request = SaveResultsAsCsvRequestParams()
         self.request.file_path = "TestPath"
         self.request.include_headers = True
@@ -38,7 +38,7 @@ class TestSaveAsCsvWriter(unittest.TestCase):
 
         self.writer = SaveAsCsvWriter(self.mock_io, self.request)
 
-    def test_write_row(self):
+    def test_write_row(self) -> None:
         writer_mock = mock.MagicMock()
         csv_writer_mock = mock.Mock(return_value=writer_mock)
         with mock.patch("csv.writer", new=csv_writer_mock):
@@ -54,7 +54,7 @@ class TestSaveAsCsvWriter(unittest.TestCase):
             self.assertEqual(["Name", "Id", "Valid"], write_row_args[0][0][0])
             self.assertEqual(["Test", "1023", "False"], write_row_args[1][0][0])
 
-    def test_write_row_for_few_columns(self):
+    def test_write_row_for_few_columns(self) -> None:
         self.writer._column_start_index = 1
         self.writer._column_end_index = 2
 
@@ -70,10 +70,11 @@ class TestSaveAsCsvWriter(unittest.TestCase):
             self.assertEqual(writer_mock.writerow.call_count, 2)
             write_row_args = writer_mock.writerow.call_args_list
 
+            self.assertEqual(2, len(write_row_args))
             self.assertEqual(["Id", "Valid"], write_row_args[0][0][0])
             self.assertEqual(["1023", "False"], write_row_args[1][0][0])
 
-    def test_write_row_change_delimiter(self):
+    def test_write_row_change_delimiter(self) -> None:
         self.request.delimiter = ";"
         writer_mock = mock.MagicMock()
         csv_writer_mock = mock.Mock(return_value=writer_mock)

--- a/tests/query/data_storage/test_save_as_excel_writer.py
+++ b/tests/query/data_storage/test_save_as_excel_writer.py
@@ -12,7 +12,7 @@ from ossdbtoolsservice.query_execution.contracts import SaveResultsAsExcelReques
 
 
 class TestSaveAsExcelWriter(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.request = SaveResultsAsExcelRequestParams()
         self.request.file_path = "TestPath"
         self.request.include_headers = True
@@ -45,11 +45,11 @@ class TestSaveAsExcelWriter(unittest.TestCase):
         with mock.patch("xlsxwriter.Workbook", new=self.xlsxwriter_mock):
             self.writer = SaveAsExcelWriter(self.mock_io, self.request)
 
-    def test_construction(self):
+    def test_construction(self) -> None:
         self.xlsxwriter_mock.assert_called_once_with(self.mock_io.name)
         self.workbook_mock.add_worksheet.assert_called_once()
 
-    def test_write_row_column_headers(self):
+    def test_write_row_column_headers(self) -> None:
         bold = {}
         self.workbook_mock.add_format = mock.Mock(return_value=bold)
         self.writer.write_row(self.row, self.columns)
@@ -70,7 +70,7 @@ class TestSaveAsExcelWriter(unittest.TestCase):
         self.assertEqual("Valid", write_column_header_args[2][0][2])
         self.assertEqual(bold, write_column_header_args[2][0][3])
 
-    def test_write_row(self):
+    def test_write_row(self) -> None:
         self.writer.write_row(self.row, self.columns)
 
         write_column_value_args = self.worksheet_mock.write.call_args_list
@@ -87,6 +87,18 @@ class TestSaveAsExcelWriter(unittest.TestCase):
         self.assertEqual(2, write_column_value_args[5][0][1])
         self.assertEqual(False, write_column_value_args[5][0][2])
 
-    def test_complete_write(self):
+    def test_write_row_for_selection(self) -> None:
+        self.writer._column_start_index = 1
+        self.writer._column_end_index = 2
+        self.writer.write_row(self.row, self.columns)
+        write_column_value_args = self.worksheet_mock.write.call_args_list
+
+        self.assertEqual("Id", write_column_value_args[0][0][2])
+        self.assertEqual("Valid", write_column_value_args[1][0][2])
+
+        self.assertEqual(1023, write_column_value_args[2][0][2])
+        self.assertEqual(False, write_column_value_args[3][0][2])
+
+    def test_complete_write(self) -> None:
         self.writer.complete_write()
         self.workbook_mock.close.assert_called_once()

--- a/tests/query/data_storage/test_save_as_json_writer.py
+++ b/tests/query/data_storage/test_save_as_json_writer.py
@@ -54,6 +54,17 @@ class TestSaveAsJsonWriter(unittest.TestCase):
         self.assertEqual(1023, self.writer._data[0]["Id"])
         self.assertEqual(False, self.writer._data[0]["Valid"])
 
+    def test_write_row_for_selection(self) -> None:
+        self.writer._column_start_index = 1
+        self.writer._column_end_index = 2
+        self.writer.write_row(self.row, self.columns)
+
+        self.assertEqual(1, len(self.writer._data))
+
+        self.assertNotIn("Name", self.writer._data[0])
+        self.assertEqual(1023, self.writer._data[0]["Id"])
+        self.assertEqual(False, self.writer._data[0]["Valid"])
+
     def test_complete_write(self) -> None:
         json_dump_mock = mock.MagicMock()
 


### PR DESCRIPTION
Results Exports that included column subsets (selections from the results viewer) incorrectly calculated the "end" column. This resulted in these exports having the correct number of rows, but no data, as the column range produced an empty iteration.

Also add indentation formatting to "scripts" from the ScriptingService, which were previously without indentation.

Fixes https://github.com/azure-data-database-platform/vs-code-postgresql/issues/157
Fixes https://github.com/azure-data-database-platform/vs-code-postgresql/issues/175