### PR TITLE
Remove message content from logs

### DIFF
--- a/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
+++ b/ossdbtoolsservice/capabilities/connection_options/pg_connection_options.py
@@ -113,6 +113,7 @@ pg_conn_provider_opts = ConnectionProviderOptions(
             description="The client encoding for the connection",
             value_type=ConnectionOption.VALUE_TYPE_STRING,
             group_name="Client",
+            default_value="utf8",
         ),
         ConnectionOption(
             name="options",

--- a/ossdbtoolsservice/hosting/json_writer.py
+++ b/ossdbtoolsservice/hosting/json_writer.py
@@ -86,7 +86,6 @@ class StreamJSONRPCWriter(JSONRPCWriter):
                     f"{message.message_type.name} message sent "
                     f"id={message.message_id} "
                     f"method={message.message_method} "
-                    f"{json_content}"
                 )
 
             # Uncomment for verbose logging


### PR DESCRIPTION
The json message content of the LSP contain values directly from a user database. These messages shouldn't be logged or persisted anywhere, so the entire content of the message has been removed.

Also updates the default value for client_encoding to instruct clients to prefer utf8 if not user value is specified.

Fixes #527 