### PR TITLE
Remove formatting for scripting service

### DIFF
--- a/ossdbtoolsservice/chat/completion/vscode_chat_completion.py
+++ b/ossdbtoolsservice/chat/completion/vscode_chat_completion.py
@@ -49,7 +49,14 @@ from .vscode_chat_prompt_execution_settings import VSCodeChatPromptExecutionSett
 
 class VSCodeChatCompletion(ChatCompletionClientBase):
     """
-    A class to interact with the VS Code GitHub Copilot LLMs
+    An implementation of a ChatCompletionClient that uses Language Server Protocol (LSP)
+    JSON-RPC messages to communicate with the VSCode Lamange Model (vscode.lm) API.
+    This class allows Semantic Kernel to leverage GitHub Copilot LLMs in chat responses.
+
+    Completion requests are sent to VSCode via LSP notifications, at which time the
+    code here starts listening for LSP notifications that are streaming responses from
+    the Language Model call. These responses are translated and handled by Semantic Kernel,
+    including tool calls. 
     """
 
     SUPPORTS_FUNCTION_CALLING: ClassVar[bool] = True

--- a/ossdbtoolsservice/scripting/scripting_service.py
+++ b/ossdbtoolsservice/scripting/scripting_service.py
@@ -5,8 +5,6 @@
 
 from typing import Optional
 
-import sqlparse
-
 from ossdbtoolsservice.connection.connection_service import ConnectionService
 from ossdbtoolsservice.connection.contracts import ConnectionType
 from ossdbtoolsservice.driver.types.driver import ServerConnection
@@ -82,8 +80,7 @@ class ScriptingService(Service):
             scripter = Scripter(connection)
 
             script = scripter.script(scripting_operation, object_metadata)
-            formatted_script = sqlparse.format(script, reindent=True)
-            request_context.send_response(ScriptAsResponse(owner_uri, formatted_script))
+            request_context.send_response(ScriptAsResponse(owner_uri, script))
         except Exception as e:
             if connection is not None and connection.connection.broken and not retry_state:
                 self._log_warning(

--- a/pgsmo/objects/table/templates/+default/select.sql
+++ b/pgsmo/objects/table/templates/+default/select.sql
@@ -2,6 +2,6 @@
  # Copyright (c) Microsoft Corporation. All rights reserved.
  # Licensed under the MIT License. See License.txt in the project root for license information.
  #}
-select {% if data.columns and data.columns|length > 0 %} {% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{'\n,'}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
-from {{conn|qtIdent(data.schema, data.name)}}
-LIMIT 1000
+SELECT {% if data.columns and data.columns|length > 0 %}{% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{',\n       '}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
+FROM {{conn|qtIdent(data.schema, data.name)}}
+LIMIT 1000;

--- a/pgsmo/objects/view/materialized_view_templates/pg/9.3_plus/select.sql
+++ b/pgsmo/objects/view/materialized_view_templates/pg/9.3_plus/select.sql
@@ -2,6 +2,7 @@
  # Copyright (c) Microsoft Corporation. All rights reserved.
  # Licensed under the MIT License. See License.txt in the project root for license information.
  #}
-select {% if data.columns and data.columns|length > 0 %} {% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{'\n,'}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
-from {{conn|qtIdent(data.schema, data.name)}}
-LIMIT 1000
+SELECT {% if data.columns and data.columns|length > 0 %}{% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{',\n       '}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
+FROM {{conn|qtIdent(data.schema, data.name)}}
+
+LIMIT 1000;

--- a/pgsmo/objects/view/view_templates/pg/9.1_plus/select.sql
+++ b/pgsmo/objects/view/view_templates/pg/9.1_plus/select.sql
@@ -2,6 +2,6 @@
  # Copyright (c) Microsoft Corporation. All rights reserved.
  # Licensed under the MIT License. See License.txt in the project root for license information.
  #}
-select {% if data.columns and data.columns|length > 0 %} {% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{'\n,'}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
-from {{conn|qtIdent(data.schema, data.name)}}
-LIMIT 1000
+SELECT {% if data.columns and data.columns|length > 0 %}{% for c in data.columns %}{% if c.name %}{% if loop.index != 1 %}{{',\n       '}}{% endif %}{{conn|qtIdent(c.name)}}{% endif %}{% endfor %}{% endif %}{{'\r'}}
+FROM {{conn|qtIdent(data.schema, data.name)}}
+LIMIT 1000;


### PR DESCRIPTION
The scripting service recently was changed to include sqlparse formatting prior to returning the generated sql. However, this formatting doesn't produce well formatted results in many cases. Instead, the formatter calls were removed, and the sql templates that were producing the original poorly formatted results were changed to be formatted nicely, as all other scripting templates are.

The formatting is still an issue in generally, and that is being tracked here https://github.com/microsoft/pgtoolsservice/issues/533