### PR TITLE
Chat fixes

### DIFF
--- a/ossdbtoolsservice/chat/chat_service.py
+++ b/ossdbtoolsservice/chat/chat_service.py
@@ -25,6 +25,9 @@ from semantic_kernel.contents import (
     FunctionResultContent,
     TextContent,
 )
+from semantic_kernel.contents import (
+    ChatMessageContent as SKChatMessageContent,
+)
 from semantic_kernel.kernel import Kernel
 
 from ossdbtoolsservice.chat.chat_history_manager import ChatHistoryManager
@@ -284,11 +287,11 @@ class ChatService(Service):
 
                 # Get function call content out of history
                 if session_id:
-                    last_user_message: str | None = None
+                    last_user_message: SKChatMessageContent | None = None
                     tool_calls: dict[str, FunctionCallContent] = {}
                     for message in history.messages:
                         if message.role == AuthorRole.USER and message.content:
-                            last_user_message = message.content
+                            last_user_message = message
                         elif (
                             message.role == AuthorRole.ASSISTANT
                             or message.role == AuthorRole.TOOL

--- a/ossdbtoolsservice/connection/core/connection_manager.py
+++ b/ossdbtoolsservice/connection/core/connection_manager.py
@@ -513,6 +513,12 @@ class ConnectionManager:
             # not have been returned from the pool.
             # Set autocommit to True.
             conn.autocommit = True
+
+            # Disable prepared statements for the connection.
+            # This is to avoid issues with prepared statements
+            # being reused across connections.
+            conn.prepare_threshold = None
+
             # If this is an long lived connection, set the pool so that
             # it can be manually returned to the pool.
             return ServerConnection(conn, pool, pooled_connection)


### PR DESCRIPTION
This PR fixes two issues:

### Chat history hashing issue

Previously, the user message hash was used to identify a spot in a conversation history that the tool call history should be inserted. This presented an issue whe messages from the user were the same - particularly, "yes" is a common message because the model often asks "would you like me to proceed?". This would cause an error when the chat history manager attempted to insert a tool call history multiple times.

Instead, we use the index of the user message in the chat history as the identifier. This should remain consistent across CompletionRequest calls as the history is append-only for a single session.


### Prepared statements in pooled connections

Errors were popping up around psycopg-generated prepared statements not existing. This is likely due to the sharing of connections via the connection pool in different scenarios. This change avoids psycopg from automatically triggering a prepared statement when a statement occurs 3 times. This may result in some performance hit for queries that happen over and over, but avoid correct queries returning errors. We'll need to manually prepare statements when using pooled connections if we want that speedup.