### PR TITLE
Fixes issue with azure token refresh

### DIFF
--- a/ossdbtoolsservice/connection/contracts/common.py
+++ b/ossdbtoolsservice/connection/contracts/common.py
@@ -249,10 +249,18 @@ class ConnectionDetails(Serializable):
         """
         Returns hash of the connection details.
         """
+        # If the connection uses Entra authentication,
+        # the password field does not identify the connection -
+        # after refresh, the connection parameters will have a different
+        # password value but represent the same connection.
+        # So we remove the password from the connection parameters
+        # before hashing.
+        connection_params = self.get_connection_params()
+        if self.azure_token and "password" in connection_params:
+            del connection_params["password"]
+
         conninfo = " ".join(
-            f"{k}={str(v)}"
-            for (k, v) in sorted(self.get_connection_params().items())
-            if v is not None
+            f"{k}={str(v)}" for (k, v) in sorted(connection_params.items()) if v is not None
         )
         return hash(conninfo)
 

--- a/tests/workspace/test_workspace_service.py
+++ b/tests/workspace/test_workspace_service.py
@@ -133,7 +133,7 @@ class TestWorkspaceService(unittest.TestCase):
                             "identifier_case": "lower",
                             "strip_comments": True,
                             "reindent": False,
-                        }
+                        },
                     },
                 }
             }

--- a/tests_v2/connection/conftest.py
+++ b/tests_v2/connection/conftest.py
@@ -28,13 +28,11 @@ class MockConnectionClassFactory(ConnectionClassFactoryBase):
         self,
         details: ConnectionDetails,
         store_connection_error: Callable[[ConnectionDetails, Exception], None],
-        maybe_refresh_azure_token: Callable[[ConnectionDetails], AzureToken | None] | None,
+        get_azure_token: Callable[[ConnectionDetails], AzureToken | None] | None,
     ) -> type[Connection[TupleRow]]:
         def get_mock_connection(*args: Any, **kwargs: Any) -> Connection[TupleRow]:
-            nonlocal maybe_refresh_azure_token
-            ConnectionClassFactory.maybe_handle_azure_token(
-                details, maybe_refresh_azure_token, kwargs
-            )
+            nonlocal get_azure_token
+            ConnectionClassFactory.maybe_set_azure_token(details, get_azure_token, kwargs)
 
             # MOCK: Connection Info
             mock_connection_info = mock.Mock()

--- a/tests_v2/connection/core/test_connection_details.py
+++ b/tests_v2/connection/core/test_connection_details.py
@@ -1,0 +1,27 @@
+from ossdbtoolsservice.connection.contracts.common import ConnectionDetails
+
+
+def test_connection_details_hash_with_azure() -> None:
+    """
+    Test the hash function of ConnectionDetails with Azure.
+    """
+    details = ConnectionDetails.from_data( {
+        "host": "localhost",
+        "port": 5432,
+        "dbname": "testdb",
+        "user": "testuser",
+        "azureAccountToken": "testtoken",
+        "azureTokenExpiry": 1234567890,
+    })
+
+    # Represents the connection after a token refresh
+    details_after_refresh = ConnectionDetails.from_data({
+        "host": "localhost",
+        "port": 5432,
+        "dbname": "testdb",
+        "user": "testuser",
+        "azureAccountToken": "testtoken2",
+        "azureTokenExpiry": 1234567891,
+    })
+    
+    assert details.to_hash() == details_after_refresh.to_hash()

--- a/tests_v2/connection/core/test_connection_manager.py
+++ b/tests_v2/connection/core/test_connection_manager.py
@@ -15,6 +15,7 @@ from ossdbtoolsservice.connection.core.connection_manager import ConnectionManag
 from ossdbtoolsservice.connection.core.errors import GetConnectionTimeout
 from ossdbtoolsservice.workspace.contracts.configuration import Configuration
 from tests_v2.connection.conftest import MockConnectionClassFactory, StubConnectionManager
+from tests_v2.test_utils.utils import is_debugger_active
 
 
 def get_connection_details() -> ConnectionDetails:
@@ -321,6 +322,7 @@ def test_fetches_expired_azure_token(
     connection_manager = ConnectionManager(
         fetch_azure_token=mock_fetch_token,
         connection_class_factory=mock_connection_class_factory,
+        timeout_override=10000 if is_debugger_active() else None,
     )
 
     owner_uri = "test_owner_uri_1"
@@ -332,6 +334,7 @@ def test_fetches_expired_azure_token(
     connection_manager.connect(owner_uri, details, config=Configuration())
 
     assert mock_fetch_token.called
+    assert mock_fetch_token.return_value.token == "new_token"
 
 
 def test_two_threads_against_expired_token_refreshes_once(


### PR DESCRIPTION
There was some bad logic in the azure token refresh for the connection manager; this PR fixes that.

First issue was that the new azure token was being set into the ConnectionDetails object, with the intention that the new token would be used in future connection params in the pool. However, the setting of the azure token to the password field happened once on ConnectionPool initialization during details.get_connection_params(), which gave ConnectionPool a static dictionary of values for connection parameters. Updating the connection detail token had no effect on the password connection parameter in this case.

Additionally, the refresh logic was incorrectly setting the entire AzureToken class to the kwargs['password'] field for the initial refresh connection parameters, which were being modified from the connection class when a refresh is necessary.

Behavior these issues caused was, in the case where an Azure token would need to be refreshed, the first connection attempt would result in an invalid token error (as it was using the AzureToken class as the passwords instead of the token string), and then subsequent connection calls would try to use the now-expired token that was previously set into the connection params and would raise an error about the expiration of the token.

Now, the connection class will always set the azure token string into the password field from the connection details. If a refresh happens, the details are updated, which will then be used in subsequent calls to update the password connection parameter.